### PR TITLE
feat: add -env-file flag for dotenv loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,18 @@ Each project gets its own isolated SQLite database at `<project>/.memory/memory.
 | `PROJECT_MEMORY_HALF_LIFE_WEEKS` | `52` | Decay half-life for project memory |
 | `COMPACT_SNIPPET_LENGTH` | `120` | Max chars per observation in compact mode |
 
+### Loading config from a .env file
+
+Some MCP clients (e.g. Kilo, opencode-derivatives) ignore the `env` block in their server config — only `command` and `args` are portable. Use the `-env-file` flag to load variables from a file:
+
+```
+workmem -env-file /path/to/.env
+```
+
+The parser mirrors the reference Node loader: `KEY=value`, single/double quotes, `# comments`, `export KEY=value`, BOM, CRLF. No variable interpolation, no multi-line, no escape sequences. Missing file is not an error (silent fallback to defaults).
+
+**Precedence:** explicit process env > `-env-file` values > built-in defaults. A key already present in the environment — even set to an empty string — is never overwritten by the file.
+
 ## Running multiple instances
 
 A common pattern: one for general knowledge, one for private notes. The client sees them as separate tool namespaces:
@@ -158,18 +170,18 @@ A common pattern: one for general knowledge, one for private notes. The client s
 {
   "mcpServers": {
     "memory": {
-      "command": "/path/to/workmem"
+      "command": "/path/to/workmem",
+      "args": ["-env-file", "/path/to/memory/.env"]
     },
     "private_memory": {
       "command": "/path/to/workmem",
-      "env": {
-        "MEMORY_DB_PATH": "/path/to/private/memory.db",
-        "MEMORY_HALF_LIFE_WEEKS": "26"
-      }
+      "args": ["-env-file", "/path/to/private-memory/.env"]
     }
   }
 }
 ```
+
+Each `.env` holds that instance's `MEMORY_DB_PATH`, `MEMORY_HALF_LIFE_WEEKS`, and any other overrides — no duplication in the client config. For clients that support it, the `env` block still works and takes precedence over the file.
 
 ## Recommended LLM instructions
 

--- a/cmd/workmem/main.go
+++ b/cmd/workmem/main.go
@@ -38,10 +38,8 @@ func runMCP(args []string) {
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 	dbPath := fs.String("db", "", "path to the SQLite database file")
 	envFile := fs.String("env-file", "", "path to a .env file to load before starting (process env wins over file values)")
-	if err := fs.Parse(args); err != nil {
-		fmt.Fprintf(os.Stderr, "parse flags: %v\n", err)
-		os.Exit(2)
-	}
+	// flag.ExitOnError calls os.Exit on parse failure — no need to check err.
+	_ = fs.Parse(args)
 
 	loadEnvFile(*envFile)
 
@@ -64,10 +62,8 @@ func runSQLiteCanary(args []string) {
 	fs := flag.NewFlagSet("sqlite-canary", flag.ExitOnError)
 	dbPath := fs.String("db", "", "path to the SQLite database file")
 	envFile := fs.String("env-file", "", "path to a .env file to load before starting (process env wins over file values)")
-	if err := fs.Parse(args); err != nil {
-		fmt.Fprintf(os.Stderr, "parse flags: %v\n", err)
-		os.Exit(2)
-	}
+	// flag.ExitOnError calls os.Exit on parse failure — no need to check err.
+	_ = fs.Parse(args)
 
 	loadEnvFile(*envFile)
 

--- a/cmd/workmem/main.go
+++ b/cmd/workmem/main.go
@@ -14,16 +14,19 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 2 || os.Args[1] == "serve" || os.Args[1][0] == '-' {
-		runMCP(os.Args[1:])
+	if len(os.Args) < 2 {
+		runMCP(nil)
 		return
 	}
 
-	switch os.Args[1] {
-	case "sqlite-canary":
-		runSQLiteCanary(os.Args[2:])
-	case "serve":
+	switch {
+	case os.Args[1] == "serve":
 		runMCP(os.Args[2:])
+	case os.Args[1] == "sqlite-canary":
+		runSQLiteCanary(os.Args[2:])
+	case os.Args[1][0] == '-':
+		// no subcommand, treat remaining args as flags for the default (serve) command
+		runMCP(os.Args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", os.Args[1])
 		printUsage()

--- a/cmd/workmem/main.go
+++ b/cmd/workmem/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"workmem/internal/dotenv"
 	"workmem/internal/mcpserver"
 	"workmem/internal/store"
 )
@@ -33,10 +34,13 @@ func main() {
 func runMCP(args []string) {
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 	dbPath := fs.String("db", "", "path to the SQLite database file")
+	envFile := fs.String("env-file", "", "path to a .env file to load before starting (process env wins over file values)")
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintf(os.Stderr, "parse flags: %v\n", err)
 		os.Exit(2)
 	}
+
+	loadEnvFile(*envFile)
 
 	runtime, err := mcpserver.New(mcpserver.Config{DBPath: *dbPath})
 	if err != nil {
@@ -56,10 +60,13 @@ func runMCP(args []string) {
 func runSQLiteCanary(args []string) {
 	fs := flag.NewFlagSet("sqlite-canary", flag.ExitOnError)
 	dbPath := fs.String("db", "", "path to the SQLite database file")
+	envFile := fs.String("env-file", "", "path to a .env file to load before starting (process env wins over file values)")
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintf(os.Stderr, "parse flags: %v\n", err)
 		os.Exit(2)
 	}
+
+	loadEnvFile(*envFile)
 
 	result, err := store.RunSQLiteCanary(*dbPath)
 	if err != nil {
@@ -78,10 +85,25 @@ func runSQLiteCanary(args []string) {
 	fmt.Printf("persisted_observations=%d\n", result.PersistedObservationCount)
 }
 
+// loadEnvFile loads the given .env file if non-empty. Errors are logged to
+// stderr and the process continues with whatever environment it already has —
+// a failed .env load must not prevent the server from starting.
+func loadEnvFile(path string) {
+	if path == "" {
+		return
+	}
+	if err := dotenv.Load(path); err != nil {
+		fmt.Fprintf(os.Stderr, "[workmem] warning: cannot load env-file: %v\n", err)
+	}
+}
+
 func printUsage() {
 	fmt.Fprintf(os.Stderr, "usage: workmem [serve] [flags]\n")
 	fmt.Fprintf(os.Stderr, "       workmem <command> [flags]\n\n")
 	fmt.Fprintf(os.Stderr, "commands:\n")
 	fmt.Fprintf(os.Stderr, "  serve           run the MCP server over stdio (default)\n")
-	fmt.Fprintf(os.Stderr, "  sqlite-canary   prove schema init, FTS insert/match/delete, and persistence\n")
+	fmt.Fprintf(os.Stderr, "  sqlite-canary   prove schema init, FTS insert/match/delete, and persistence\n\n")
+	fmt.Fprintf(os.Stderr, "flags (all commands):\n")
+	fmt.Fprintf(os.Stderr, "  -db <path>        path to the SQLite database file\n")
+	fmt.Fprintf(os.Stderr, "  -env-file <path>  load variables from a .env file (process env takes precedence)\n")
 }

--- a/internal/dotenv/dotenv.go
+++ b/internal/dotenv/dotenv.go
@@ -1,0 +1,153 @@
+// Package dotenv loads values from a .env file into os.Environ().
+//
+// The parser mirrors the zero-dependency loader in the reference Node server
+// (mcp-memory/server.js). Process env precedence is honored via os.LookupEnv:
+// a key already present in the environment is never overwritten, even if its
+// value is the empty string. A missing file is not an error (ENOENT silence).
+//
+// Supported syntax:
+//
+//	KEY=value                     # simple assignment
+//	KEY="value with spaces"       # double quotes (no escapes, no interpolation)
+//	KEY='value with spaces'       # single quotes (no escapes, no interpolation)
+//	KEY=value # trailing comment  # inline comment (unquoted only, needs whitespace before #)
+//	KEY="value # literal hash"    # hash is literal inside quotes
+//	export KEY=value              # bash-style export prefix (allowed, stripped)
+//	# full-line comment           # skipped
+//	KEY=                          # empty string (key present, value empty)
+//
+// NOT supported: variable interpolation (${OTHER}), multi-line values,
+// escape sequences inside quotes.
+//
+// Lines that don't match KEY=VALUE shape are skipped silently.
+package dotenv
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// Parse converts .env file content into a map of key/value pairs.
+// Malformed lines are skipped silently (matches the reference Node parser).
+func Parse(content string) map[string]string {
+	result := map[string]string{}
+
+	// Strip UTF-8 BOM if present (some Windows editors add it).
+	content = strings.TrimPrefix(content, "\uFEFF")
+
+	// Split on LF; trailing \r on each line is stripped below (CRLF).
+	for rawLine := range strings.SplitSeq(content, "\n") {
+		rawLine = strings.TrimSuffix(rawLine, "\r")
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Allow optional 'export ' prefix (bash-compatible).
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimLeft(line[len("export "):], " \t")
+		}
+
+		keyRaw, rawValue, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+
+		key := strings.TrimSpace(keyRaw)
+		if !isValidKey(key) {
+			continue
+		}
+
+		// Drop leading whitespace after =; trailing handling depends on quoting.
+		rest := strings.TrimLeft(rawValue, " \t")
+
+		var value string
+		if strings.HasPrefix(rest, `"`) || strings.HasPrefix(rest, `'`) {
+			quote := rest[0]
+			closeIdx := strings.IndexByte(rest[1:], quote)
+			if closeIdx == -1 {
+				// Unterminated quote — skip line entirely.
+				continue
+			}
+			value = rest[1 : 1+closeIdx]
+			// Content after the closing quote is ignored (whitespace, comment, garbage).
+		} else {
+			// Unquoted: strip inline comment (whitespace followed by #), then trim trailing.
+			if idx := findInlineCommentStart(rest); idx >= 0 {
+				value = rest[:idx]
+			} else {
+				value = rest
+			}
+			value = strings.TrimRight(value, " \t")
+		}
+
+		result[key] = value
+	}
+	return result
+}
+
+// Load reads the file at path, parses it, and injects keys not already in
+// the environment via os.Setenv. Existing env values win (LookupEnv-based
+// precedence — empty-string-set-in-env also wins, matching Node semantics).
+//
+// Returns nil if the file does not exist (ENOENT silence). Returns an error
+// for other read failures; callers typically log and continue.
+// An empty path is treated as "don't load" and returns nil.
+func Load(path string) error {
+	if path == "" {
+		return nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read env file %q: %w", path, err)
+	}
+	for key, value := range Parse(string(content)) {
+		if _, ok := os.LookupEnv(key); ok {
+			continue
+		}
+		if setErr := os.Setenv(key, value); setErr != nil {
+			return fmt.Errorf("set env %q: %w", key, setErr)
+		}
+	}
+	return nil
+}
+
+// isValidKey reports whether key is a valid env var identifier:
+// matches the regex ^[A-Za-z_][A-Za-z0-9_]*$ without pulling regexp.
+func isValidKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i := 0; i < len(key); i++ {
+		c := key[i]
+		if c == '_' ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= 'a' && c <= 'z') {
+			continue
+		}
+		if i > 0 && c >= '0' && c <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// findInlineCommentStart returns the index of an inline comment marker —
+// whitespace (space or tab) immediately followed by #. Returns -1 if none.
+// Matches the reference parser's /\s#/ intent (restricted here to space/tab
+// since newlines cannot appear within a single parsed line).
+func findInlineCommentStart(s string) int {
+	for i := 0; i < len(s)-1; i++ {
+		if (s[i] == ' ' || s[i] == '\t') && s[i+1] == '#' {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/dotenv/dotenv_test.go
+++ b/internal/dotenv/dotenv_test.go
@@ -190,8 +190,17 @@ func TestLoadMissingFile(t *testing.T) {
 
 func TestLoadFillsUnsetKeys(t *testing.T) {
 	const key = "WORKMEM_DOTENV_TEST_FILLS_UNSET"
+	// Snapshot any pre-existing value so the test stays hermetic if the
+	// caller happens to have this key set in their environment.
+	oldValue, hadValue := os.LookupEnv(key)
 	os.Unsetenv(key)
-	t.Cleanup(func() { os.Unsetenv(key) })
+	t.Cleanup(func() {
+		if hadValue {
+			os.Setenv(key, oldValue)
+			return
+		}
+		os.Unsetenv(key)
+	})
 
 	path := writeEnvFile(t, key+"=from-dotenv")
 	if err := Load(path); err != nil {

--- a/internal/dotenv/dotenv_test.go
+++ b/internal/dotenv/dotenv_test.go
@@ -1,0 +1,260 @@
+package dotenv
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  map[string]string
+	}{
+		{
+			name:  "simple assignment",
+			input: "FOO=bar",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "double quoted value",
+			input: `FOO="bar baz"`,
+			want:  map[string]string{"FOO": "bar baz"},
+		},
+		{
+			name:  "single quoted value",
+			input: `FOO='bar baz'`,
+			want:  map[string]string{"FOO": "bar baz"},
+		},
+		{
+			name:  "inline comment stripped after whitespace",
+			input: "FOO=bar # trailing comment",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "hash without preceding whitespace is literal",
+			input: "FOO=bar#baz",
+			want:  map[string]string{"FOO": "bar#baz"},
+		},
+		{
+			name:  "hash inside double quotes is literal",
+			input: `FOO="bar # still quoted"`,
+			want:  map[string]string{"FOO": "bar # still quoted"},
+		},
+		{
+			name:  "hash inside single quotes is literal",
+			input: `FOO='bar # still quoted'`,
+			want:  map[string]string{"FOO": "bar # still quoted"},
+		},
+		{
+			name:  "export prefix stripped",
+			input: "export FOO=bar",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "export with extra whitespace",
+			input: "export   FOO=bar",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "full-line comment skipped",
+			input: "# this is a comment\nFOO=bar",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "empty value is preserved",
+			input: "FOO=",
+			want:  map[string]string{"FOO": ""},
+		},
+		{
+			name:  "CRLF line endings",
+			input: "FOO=bar\r\nBAZ=qux\r\n",
+			want:  map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			name:  "UTF-8 BOM at file start",
+			input: "\uFEFFFOO=bar",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "BOM combined with CRLF",
+			input: "\uFEFFFOO=bar\r\n",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "blank lines between entries",
+			input: "FOO=bar\n\n\nBAZ=qux\n",
+			want:  map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			name:  "key starting with digit is rejected",
+			input: "1FOO=bar",
+			want:  map[string]string{},
+		},
+		{
+			name:  "key with dash is rejected",
+			input: "FOO-BAR=baz",
+			want:  map[string]string{},
+		},
+		{
+			name:  "key with dot is rejected",
+			input: "FOO.BAR=baz",
+			want:  map[string]string{},
+		},
+		{
+			name:  "line without equals is skipped",
+			input: "not an assignment\nFOO=bar",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "unterminated double quote skips line",
+			input: `FOO="unterminated` + "\nBAR=ok",
+			want:  map[string]string{"BAR": "ok"},
+		},
+		{
+			name:  "unterminated single quote skips line",
+			input: "FOO='unterminated\nBAR=ok",
+			want:  map[string]string{"BAR": "ok"},
+		},
+		{
+			name:  "trailing whitespace on unquoted value trimmed",
+			input: "FOO=bar   \t",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "leading whitespace after equals trimmed",
+			input: "FOO=   bar",
+			want:  map[string]string{"FOO": "bar"},
+		},
+		{
+			name:  "multiple equals in value preserved after first",
+			input: "FOO=a=b=c",
+			want:  map[string]string{"FOO": "a=b=c"},
+		},
+		{
+			name:  "trailing garbage after closing quote ignored",
+			input: `FOO="hello" and then garbage # comment`,
+			want:  map[string]string{"FOO": "hello"},
+		},
+		{
+			name:  "underscore-prefixed key accepted",
+			input: "_FOO=bar",
+			want:  map[string]string{"_FOO": "bar"},
+		},
+		{
+			name:  "numeric chars inside key accepted",
+			input: "FOO123=bar",
+			want:  map[string]string{"FOO123": "bar"},
+		},
+		{
+			name:  "empty input returns empty map",
+			input: "",
+			want:  map[string]string{},
+		},
+		{
+			name:  "whitespace-only value becomes empty",
+			input: "FOO=   \t   ",
+			want:  map[string]string{"FOO": ""},
+		},
+		{
+			name:  "unicode inside quoted value preserved",
+			input: `FOO="caffè — β"`,
+			want:  map[string]string{"FOO": "caffè — β"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Parse(tc.input)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Parse() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadEmptyPath(t *testing.T) {
+	if err := Load(""); err != nil {
+		t.Fatalf("Load(\"\") = %v, want nil", err)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.env")
+	if err := Load(missing); err != nil {
+		t.Fatalf("Load(missing) = %v, want nil (ENOENT silence)", err)
+	}
+}
+
+func TestLoadReadError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-denied read not reproducible the same way on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unreadable.env")
+	if err := os.WriteFile(path, []byte("FOO=bar"), 0o000); err != nil {
+		t.Fatalf("WriteFile() = %v", err)
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses permission check")
+	}
+	err := Load(path)
+	if err == nil {
+		t.Fatalf("Load() on permission-denied file = nil, want error")
+	}
+}
+
+func TestLoadFillsUnsetKeys(t *testing.T) {
+	const key = "WORKMEM_DOTENV_TEST_FILLS_UNSET"
+	os.Unsetenv(key)
+	t.Cleanup(func() { os.Unsetenv(key) })
+
+	path := writeEnvFile(t, key+"=from-dotenv")
+	if err := Load(path); err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if got := os.Getenv(key); got != "from-dotenv" {
+		t.Errorf("os.Getenv(%q) = %q, want %q", key, got, "from-dotenv")
+	}
+}
+
+func TestLoadProcessEnvWinsOverDotenv(t *testing.T) {
+	const key = "WORKMEM_DOTENV_TEST_PRECEDENCE"
+	t.Setenv(key, "from-env")
+
+	path := writeEnvFile(t, key+"=from-dotenv")
+	if err := Load(path); err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if got := os.Getenv(key); got != "from-env" {
+		t.Errorf("os.Getenv(%q) = %q, want %q (process env must win)", key, got, "from-env")
+	}
+}
+
+func TestLoadEmptyStringInEnvStillWins(t *testing.T) {
+	// Document LookupEnv semantics: an explicitly-set empty string counts as
+	// "set" and is not overridden by the .env value. Matches Node's
+	// process.env[k] === undefined check.
+	const key = "WORKMEM_DOTENV_TEST_EMPTY_WINS"
+	t.Setenv(key, "")
+
+	path := writeEnvFile(t, key+"=from-dotenv")
+	if err := Load(path); err != nil {
+		t.Fatalf("Load() = %v", err)
+	}
+	if got := os.Getenv(key); got != "" {
+		t.Errorf("os.Getenv(%q) = %q, want empty string (LookupEnv treats empty as set)", key, got)
+	}
+}
+
+func writeEnvFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.env")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() = %v", err)
+	}
+	return path
+}

--- a/internal/dotenv/dotenv_test.go
+++ b/internal/dotenv/dotenv_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 )
 
@@ -186,24 +185,6 @@ func TestLoadMissingFile(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist.env")
 	if err := Load(missing); err != nil {
 		t.Fatalf("Load(missing) = %v, want nil (ENOENT silence)", err)
-	}
-}
-
-func TestLoadReadError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("permission-denied read not reproducible the same way on Windows")
-	}
-	dir := t.TempDir()
-	path := filepath.Join(dir, "unreadable.env")
-	if err := os.WriteFile(path, []byte("FOO=bar"), 0o000); err != nil {
-		t.Fatalf("WriteFile() = %v", err)
-	}
-	if os.Geteuid() == 0 {
-		t.Skip("running as root bypasses permission check")
-	}
-	err := Load(path)
-	if err == nil {
-		t.Fatalf("Load() on permission-denied file = nil, want error")
 	}
 }
 

--- a/internal/dotenv/dotenv_unix_test.go
+++ b/internal/dotenv/dotenv_unix_test.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package dotenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadReadError lives in a Unix-only file because mode 0o000 has no
+// reliable equivalent on Windows: NTFS ACLs let the file owner read the file
+// regardless of the POSIX-bit mode, so permission-denied cannot be provoked
+// portably from Go.
+func TestLoadReadError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses permission check")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unreadable.env")
+	if err := os.WriteFile(path, []byte("FOO=bar"), 0o000); err != nil {
+		t.Fatalf("WriteFile() = %v", err)
+	}
+	err := Load(path)
+	if err == nil {
+		t.Fatalf("Load() on permission-denied file = nil, want error")
+	}
+}

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -5,12 +5,24 @@ import (
 	"strconv"
 )
 
-var memoryHalfLifeWeeks = envFloat("MEMORY_HALF_LIFE_WEEKS", 12)
-var projectMemoryHalfLifeWeeks = envFloat("PROJECT_MEMORY_HALF_LIFE_WEEKS", 52)
-
 const defaultCompactSnippetLength = 120
 
-var compactSnippetLength = envInt("COMPACT_SNIPPET_LENGTH", defaultCompactSnippetLength)
+// Config getters read the process environment on every call so that values
+// injected late (e.g., by the dotenv loader in main before mcpserver.New)
+// are honored. The per-call cost is a map lookup plus a parse — negligible
+// compared to the work each tool handler does.
+
+func memoryHalfLifeWeeks() float64 {
+	return envFloat("MEMORY_HALF_LIFE_WEEKS", 12)
+}
+
+func projectMemoryHalfLifeWeeks() float64 {
+	return envFloat("PROJECT_MEMORY_HALF_LIFE_WEEKS", 52)
+}
+
+func compactSnippetLength() int {
+	return envInt("COMPACT_SNIPPET_LENGTH", defaultCompactSnippetLength)
+}
 
 func envFloat(key string, fallback float64) float64 {
 	raw := os.Getenv(key)

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -461,7 +461,7 @@ func TestRankingAndRecallParity(t *testing.T) {
 		if err != nil {
 			t.Fatalf("UpsertEntity() error = %v", err)
 		}
-		longContent := make([]byte, compactSnippetLength+80)
+		longContent := make([]byte, compactSnippetLength()+80)
 		for i := range longContent {
 			longContent[i] = 'a'
 		}
@@ -477,7 +477,7 @@ func TestRankingAndRecallParity(t *testing.T) {
 			t.Fatalf("RecallResponse.Compact = false, want true")
 		}
 		observation := result.Results[0].Observations[0]
-		if utf8.RuneCountInString(observation.Content) > compactSnippetLength || !observation.Truncated {
+		if utf8.RuneCountInString(observation.Content) > compactSnippetLength() || !observation.Truncated {
 			t.Fatalf("compact recall did not truncate correctly: %#v", observation)
 		}
 		if observation.Content[len(observation.Content)-len("…"):] != "…" {

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -353,6 +353,9 @@ func GroupResults(results []SearchObservation, compact bool) RecallResponse {
 	groups := make(map[string]int)
 	ordered := make([]RecallEntityGroup, 0)
 
+	// Resolve once per call — COMPACT_SNIPPET_LENGTH does not change within a request.
+	snippetLimit := compactSnippetLength()
+
 	for _, result := range results {
 		index, exists := groups[result.EntityName]
 		if !exists {
@@ -364,7 +367,7 @@ func GroupResults(results []SearchObservation, compact bool) RecallResponse {
 			})
 		}
 
-		content, truncated := compactContent(result.Content, compact)
+		content, truncated := compactContent(result.Content, compact, snippetLimit)
 
 		ordered[index].Observations = append(ordered[index].Observations, RecallObservation{
 			ID:             result.ID,
@@ -388,12 +391,11 @@ func GroupResults(results []SearchObservation, compact bool) RecallResponse {
 	return response
 }
 
-func compactContent(content string, compact bool) (string, bool) {
+func compactContent(content string, compact bool, limit int) (string, bool) {
 	if !compact {
 		return content, false
 	}
 	runes := []rune(content)
-	limit := compactSnippetLength()
 	if len(runes) <= limit {
 		return content, false
 	}

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -84,7 +84,7 @@ func DecayedConfidence(createdAt string, confidence float64, accessCount int64, 
 	}
 	hl := halfLifeWeeks
 	if hl == 0 {
-		hl = memoryHalfLifeWeeks
+		hl = memoryHalfLifeWeeks()
 	}
 	ageWeeks := time.Since(when).Hours() / (24 * 7)
 	stability := hl * (1 + math.Log2(float64(accessCount)+1))
@@ -393,10 +393,11 @@ func compactContent(content string, compact bool) (string, bool) {
 		return content, false
 	}
 	runes := []rune(content)
-	if len(runes) <= compactSnippetLength {
+	limit := compactSnippetLength()
+	if len(runes) <= limit {
 		return content, false
 	}
-	return string(runes[:compactSnippetLength-1]) + "…", true
+	return string(runes[:limit-1]) + "…", true
 }
 
 func addCandidate(candidateMap map[int64]*candidate, id int64, channel string, maxCandidates int, ftsPosition *int) {

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -137,9 +137,9 @@ func HandleTool(defaultDB *sql.DB, name string, args ToolArgs) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	halfLife := memoryHalfLifeWeeks
+	halfLife := memoryHalfLifeWeeks()
 	if args.Project != "" {
-		halfLife = projectMemoryHalfLifeWeeks
+		halfLife = projectMemoryHalfLifeWeeks()
 	}
 
 	switch name {


### PR DESCRIPTION
## Summary

- Add `-env-file <path>` flag that loads a `.env` file into `os.Environ()` before the MCP server starts, with process-env precedence (empty-string-set also wins via `LookupEnv`)
- New `internal/dotenv` package mirrors the reference Node loader bullet-for-bullet — quoting, inline comments, `export` prefix, BOM, CRLF, unterminated-quote skip. Zero new dependencies.
- Convert three init-time config vars in `internal/store/config.go` to lazy getter functions so values injected by the dotenv loader in `main()` are honored

## Motivation

Node `mcp-memory` loads `.env` from `__dirname`. Workmem is one shared binary serving multiple instances (general/private memory) so `__dirname` can't work. Some MCP clients (Kilo, opencode-derivatives) ignore the `env` block in their config — only `command` + `args` are portable. The `-env-file` flag lets per-instance config stay centralized in a `.env` file alongside each database, with `args: ["-env-file", "/path/to/.env"]` being the only client-side config.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green
- [x] New `internal/dotenv/dotenv_test.go` covers 30 parser cases + 6 loader cases including process-env precedence and ENOENT silence
- [x] Existing `internal/store` tests still pass with lazy getters
- [x] Manual smoke: binary starts with `-env-file /tmp/test.env`, parses CRLF file, silent on missing file
- [ ] Post-merge: update `~/.claude.json` to use `-env-file` against the existing Node server DBs, restart Claude, verify `memory` and `private_memory` namespaces return identical data

🤖 Generated with [Claude Code](https://claude.com/claude-code)