### PR TITLE
chore: gitignore docs/internal/ for local dev notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ coverage.html
 .memory/
 review/
 thinking/
+docs/internal/


### PR DESCRIPTION
## Summary

- Add `docs/internal/` to `.gitignore` so roadmap drafts, design specs, and brainstorm material can live next to the code without entering the public history
- Mirrors the convention used in the upstream Node repo (`mcp-memory`)

## Test plan

- [x] No tracked files affected (directory does not exist yet in the working tree)
- [ ] After merge: copy `~/mcp-memory/docs/internal/*.md` into `~/workmem/docs/internal/` locally; verify `git status` stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)