### PR TITLE
fix: remember_event atomicity + dead code cleanup (post-porting review)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -20,12 +20,6 @@
 
 ### P1
 
-- The Go backend now exposes MCP over stdio, but still lacks a proof against Kilo or another real external client.
-Trigger: Treating an SDK smoke test as the same thing as editor/runtime integration proof.
-Blast radius: Subtle handshake or process-launch drift survives until the first real-client wiring attempt.
-Fix: wire the binary into Kilo and run live end-to-end tool calls.
-Done when: Kilo can list tools and execute remember/recall successfully against the Go binary.
-
 - The Go port now replays the shared product fixtures locally, but still lacks an automated Node-vs-Go dual-runtime comparison in CI.
 Trigger: Trusting Go-only fixture replay as full parity proof.
 Blast radius: Drift from the JS reference can sneak in when both sides evolve independently.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -10,6 +10,7 @@
 - Project-scoped storage must never leak into global storage.
 - Live-data queries must never bypass tombstone guards.
 - FTS cleanup must never use raw `DELETE` against a contentless FTS table.
+- `remember_event` must be atomic: the event row and all attached observations commit together or not at all. Proof: `TestRememberEventAtomicityOnMidLoopFailure` in `internal/store/parity_test.go`.
 
 ## Active Debt
 

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -502,18 +502,6 @@ func getEventByID(db *sql.DB, eventID int64) (*EventRecord, error) {
 	return item, nil
 }
 
-func scanEntityRecord(rows *sql.Rows) (*EntityRecord, error) {
-	var item EntityRecord
-	var entityType sql.NullString
-	var deletedAt sql.NullString
-	if err := rows.Scan(&item.ID, &item.Name, &entityType, &deletedAt, &item.CreatedAt, &item.UpdatedAt); err != nil {
-		return nil, fmt.Errorf("scan entity record: %w", err)
-	}
-	item.EntityType = entityType.String
-	item.DeletedAt = deletedAt.String
-	return &item, nil
-}
-
 func scanEventRecord(rows *sql.Rows) (*EventRecord, error) {
 	var item EventRecord
 	var eventDate sql.NullString

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -134,7 +134,7 @@ type EventObservationsResult struct {
 	Total        int                  `json:"total"`
 }
 
-func CreateEvent(db *sql.DB, label, eventDate, eventType, context, expiresAt string) (int64, error) {
+func CreateEvent(db dbtx, label, eventDate, eventType, context, expiresAt string) (int64, error) {
 	result, err := db.Exec(
 		`INSERT INTO events (label, event_date, event_type, context, expires_at) VALUES (?, ?, ?, ?, ?)`,
 		label,

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -485,3 +485,48 @@ func TestRankingAndRecallParity(t *testing.T) {
 		}
 	})
 }
+
+func TestRememberEventAtomicityOnMidLoopFailure(t *testing.T) {
+	db := newTestDB(t, "atomicity.db")
+
+	if _, err := db.Exec(
+		`CREATE TRIGGER fail_on_sentinel BEFORE INSERT ON entities
+		 WHEN NEW.name = 'FAIL_ME'
+		 BEGIN SELECT RAISE(ABORT, 'injected failure'); END;`,
+	); err != nil {
+		t.Fatalf("install trigger: %v", err)
+	}
+
+	var eventsBefore int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events`).Scan(&eventsBefore); err != nil {
+		t.Fatalf("count events before: %v", err)
+	}
+
+	_, err := HandleTool(db, "remember_event", ToolArgs{
+		Label:     "Atomicity probe",
+		EventType: "test",
+		Observations: []FactInput{
+			{Entity: "Alpha", Observation: "first observation"},
+			{Entity: "FAIL_ME", Observation: "second observation triggers abort"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("HandleTool(remember_event) expected error from injected failure, got nil")
+	}
+
+	var eventsAfter int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM events`).Scan(&eventsAfter); err != nil {
+		t.Fatalf("count events after: %v", err)
+	}
+	if eventsAfter != eventsBefore {
+		t.Fatalf("events row count changed despite mid-loop failure: before=%d after=%d (orphan event row left behind)", eventsBefore, eventsAfter)
+	}
+
+	var alphaCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM entities WHERE name = ?`, "Alpha").Scan(&alphaCount); err != nil {
+		t.Fatalf("count Alpha entity: %v", err)
+	}
+	if alphaCount != 0 {
+		t.Fatalf("Alpha entity persisted despite rollback: count=%d", alphaCount)
+	}
+}

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -16,31 +16,30 @@ type FactInput struct {
 }
 
 type ToolArgs struct {
-	Entity          string      `json:"entity,omitempty"`
-	EntityType      string      `json:"entity_type,omitempty"`
-	Observation     string      `json:"observation,omitempty"`
-	Source          string      `json:"source,omitempty"`
-	Confidence      *float64    `json:"confidence,omitempty"`
-	EventID         *int64      `json:"event_id,omitempty"`
-	Project         string      `json:"project,omitempty"`
-	Facts           []FactInput `json:"facts,omitempty"`
-	Query           string      `json:"query,omitempty"`
-	Limit           *int        `json:"limit,omitempty"`
-	Compact         bool        `json:"compact,omitempty"`
-	From            string      `json:"from,omitempty"`
-	To              string      `json:"to,omitempty"`
-	RelationType    string      `json:"relation_type,omitempty"`
-	Context         string      `json:"context,omitempty"`
-	ObservationID   *int64      `json:"observation_id,omitempty"`
-	Label           string      `json:"label,omitempty"`
-	EventDate       string      `json:"event_date,omitempty"`
-	EventType       string      `json:"event_type,omitempty"`
-	ExpiresAt       string      `json:"expires_at,omitempty"`
-	Observations    []FactInput `json:"observations,omitempty"`
-	ObservationIDs  []int64     `json:"observation_ids,omitempty"`
-	DateFrom        string      `json:"date_from,omitempty"`
-	DateTo          string      `json:"date_to,omitempty"`
-	EventTypeFilter string      `json:"event_type_filter,omitempty"`
+	Entity         string      `json:"entity,omitempty"`
+	EntityType     string      `json:"entity_type,omitempty"`
+	Observation    string      `json:"observation,omitempty"`
+	Source         string      `json:"source,omitempty"`
+	Confidence     *float64    `json:"confidence,omitempty"`
+	EventID        *int64      `json:"event_id,omitempty"`
+	Project        string      `json:"project,omitempty"`
+	Facts          []FactInput `json:"facts,omitempty"`
+	Query          string      `json:"query,omitempty"`
+	Limit          *int        `json:"limit,omitempty"`
+	Compact        bool        `json:"compact,omitempty"`
+	From           string      `json:"from,omitempty"`
+	To             string      `json:"to,omitempty"`
+	RelationType   string      `json:"relation_type,omitempty"`
+	Context        string      `json:"context,omitempty"`
+	ObservationID  *int64      `json:"observation_id,omitempty"`
+	Label          string      `json:"label,omitempty"`
+	EventDate      string      `json:"event_date,omitempty"`
+	EventType      string      `json:"event_type,omitempty"`
+	ExpiresAt      string      `json:"expires_at,omitempty"`
+	Observations   []FactInput `json:"observations,omitempty"`
+	ObservationIDs []int64     `json:"observation_ids,omitempty"`
+	DateFrom       string      `json:"date_from,omitempty"`
+	DateTo         string      `json:"date_to,omitempty"`
 }
 
 type RememberResult struct {

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -252,31 +252,29 @@ func HandleTool(defaultDB *sql.DB, name string, args ToolArgs) (any, error) {
 		return ListEntitiesResult{Entities: entities, Total: len(entities)}, nil
 
 	case "remember_event":
-		eventID, err := CreateEvent(db, args.Label, args.EventDate, args.EventType, args.Context, args.ExpiresAt)
+		tx, err := db.Begin()
+		if err != nil {
+			return nil, fmt.Errorf("begin remember_event: %w", err)
+		}
+		defer tx.Rollback()
+		eventID, err := CreateEvent(tx, args.Label, args.EventDate, args.EventType, args.Context, args.ExpiresAt)
 		if err != nil {
 			return nil, err
 		}
 		attached := make([]RememberBatchFactResult, 0, len(args.Observations))
-		if len(args.Observations) > 0 {
-			tx, err := db.Begin()
+		for _, fact := range args.Observations {
+			entityID, err := UpsertEntity(tx, fact.Entity, fact.EntityType)
 			if err != nil {
-				return nil, fmt.Errorf("begin remember_event attachments: %w", err)
+				return nil, err
 			}
-			defer tx.Rollback()
-			for _, fact := range args.Observations {
-				entityID, err := UpsertEntity(tx, fact.Entity, fact.EntityType)
-				if err != nil {
-					return nil, err
-				}
-				observationID, err := AddObservation(tx, entityID, fact.Observation, defaultSource(fact.Source), defaultConfidence(fact.Confidence), eventID)
-				if err != nil {
-					return nil, err
-				}
-				attached = append(attached, RememberBatchFactResult{Entity: fact.Entity, EntityID: entityID, ObservationID: observationID})
+			observationID, err := AddObservation(tx, entityID, fact.Observation, defaultSource(fact.Source), defaultConfidence(fact.Confidence), eventID)
+			if err != nil {
+				return nil, err
 			}
-			if err := tx.Commit(); err != nil {
-				return nil, fmt.Errorf("commit remember_event attachments: %w", err)
-			}
+			attached = append(attached, RememberBatchFactResult{Entity: fact.Entity, EntityID: entityID, ObservationID: observationID})
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit remember_event: %w", err)
 		}
 		return RememberEventResult{Created: true, EventID: eventID, Label: args.Label, EventDate: args.EventDate, EventType: args.EventType, ObservationsAttached: len(attached), Observations: attached, Project: stringPointer(args.Project)}, nil
 


### PR DESCRIPTION
## Summary

Addresses Diana post-porting review on `8dddddf` (the Node→Go port that landed via PR #2). Findings:

- **R4 — atomic `remember_event`** (state-concurrency). `CreateEvent` wrote the event row on `*sql.DB` directly, before the observation-loop transaction opened. Any mid-loop DB error (`SQLITE_BUSY`, FK violation, disk full) left an orphan event row with zero attached observations. Fix: `CreateEvent` now accepts `dbtx`; the handler opens a single transaction covering event insert + observation loop. Rollback discards the whole unit.
- **R1 — `scanEntityRecord` dead code** removed from `events.go`. Defined but never called.
- **R2 — `EventTypeFilter` field** removed from `ToolArgs`. Declared but never read — silent no-op contract drift for any JSON caller passing `event_type_filter`. The existing `EventType` field already serves `recall_events`.
- **R3 — real-client proof** was archaeology. The binary is already wired as the MCP server backing Claude Code (via `~/.claude.json` + `governor` env files), Kilo, and Codex. Live tool calls (`remember_batch`, `recall_entity`) succeeded during this very review session. Removing the stale P1 entry from `OPERATIONS.md`.

Invariant added to `OPERATIONS.md`: *`remember_event` must be atomic — event row and all attached observations commit together or not at all.*

## Test plan

- [x] `TestRememberEventAtomicityOnMidLoopFailure` installs a `BEFORE INSERT` trigger on `entities` that `RAISE(ABORT)` on a sentinel value. Pre-fix: `before=0 after=1 (orphan event row left behind)`. Post-fix: passes.
- [x] Full `go test ./...` suite green on darwin/arm64.
- [ ] CI matrix (ubuntu / macos / windows) on this branch.

## Commits

1. `fix: make remember_event atomic against mid-loop DB errors`
2. `chore: remove dead code flagged by Diana review`
3. `docs: close R3 real-client debt — binary is already in production`