### PR TITLE
feat: conflict hints in remember response (Phase 4 Step 4.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ coverage.html
 review/
 thinking/
 docs/internal/
+analysis/

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -67,7 +67,7 @@ existing responses without changing any tool name, argument name, or
 documented field. Clients that do not know about a new field must keep
 working unchanged.
 
-### `remember` — `possible_conflicts` (pending implementation)
+### `remember` — `possible_conflicts`
 
 Motivated by the 2026-04-22 decision (`DECISION_LOG.md`). When
 `remember` stores an observation on an entity, the backend runs the

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -58,3 +58,49 @@ The initial comparison fixtures live in `testdata/contracts/` and are the baseli
 - result grouping shape
 - compact recall behavior
 - provenance response shape without explicit migration notes
+
+## Additive response extensions (post-parity)
+
+Once core parity is proven and the product starts earning its own
+evolutionary decisions, the tool surface can grow *additively* on
+existing responses without changing any tool name, argument name, or
+documented field. Clients that do not know about a new field must keep
+working unchanged.
+
+### `remember` — `possible_conflicts` (pending implementation)
+
+Motivated by the 2026-04-22 decision (`DECISION_LOG.md`). When
+`remember` stores an observation on an entity, the backend runs the
+composite ranker scoped to that entity's non-deleted observations and,
+if any score above a conservative similarity threshold, surfaces up to
+3 of them on the response:
+
+```json
+{
+  "entity_id": 42,
+  "observation_id": 999,
+  "stored": true,
+  "possible_conflicts": [
+    {"observation_id": 877, "similarity": 0.87, "snippet": "..."}
+  ]
+}
+```
+
+Contract properties:
+
+- The field is **optional**. Omitted entirely when there are no
+  qualifying conflicts. Clients that ignore the field must keep
+  working identically to the pre-extension response.
+- The field is a **hint**, not a command. The backend never
+  soft-deletes on the agent's behalf. Supersession is the agent's
+  decision, performed via `forget(observation_id)`.
+- The similarity score is a lexical signal derived from the existing
+  composite ranker. It is not a semantic contradiction score and must
+  not be documented as such.
+- `forget` semantics are unchanged. Adding `possible_conflicts`
+  extends `remember` only; nothing in the "not allowed to drift early"
+  list moves.
+- The similarity threshold is provisional at launch and calibrated via
+  telemetry (`conflicts_surfaced` vs `conflicts_acted_on`). Threshold
+  changes are implementation-internal and do not constitute a contract
+  change.

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -1,5 +1,159 @@
 # DECISION LOG
 
+## 2026-04-22: Surface near-duplicate observations in `remember` response; supersession stays agent-driven
+
+### Context
+
+workmem is working memory, not a diary. Supersession is not a first-class
+state — it is a transition implemented as `forget` followed by `remember`.
+From the agent's perspective, `forget` removes a fact from FTS and recall
+(soft-delete at the DB layer exists for backup/debug only). This ontology
+makes `forget` the only mechanism through which the canonical state
+mutates, which `OPERATIONS.md` already treats as a never-drift invariant.
+
+Eight days of production telemetry (121 tool calls across `memory` and
+`private_memory` on `claude-code`: 38 `recall`, 42 `remember`, 24
+`remember_batch`, 11 `remember_event`, 3 `forget`) now provide direct
+evidence that the ontology is not being honored in practice. On
+same-entity transitions within a 7-day window:
+
+- silent overwrites (`remember → remember` on same entity, no `forget`
+  between): **14**
+- forget corrections (`remember → forget` on same entity): **0**
+- post-forget rewrites (`forget → remember` on same entity): **0**
+
+14 of 14 same-entity updates were silent overwrites. The agent never
+used `forget` as supersession despite the recommended LLM instructions
+in the README. Old facts remain in the live set, dampened by decay but
+still recoverable by composite ranking — exactly the failure mode the
+external reviewer in `review/commenti.md` predicted for
+ranking-as-truth-resolution.
+
+The PITCH commits to "stupidity of use, solidity of backend": the model
+does not think about memory, the backend does the work. Requiring the
+agent to `recall_entity` before every `remember` violates that
+commitment and, per the telemetry, does not happen anyway.
+
+### Decision
+
+Extend the `remember` response with an optional `possible_conflicts`
+field. When storing an observation on entity E with content C, the
+backend runs the existing composite ranker scoped to
+`entity_id = E AND deleted_at IS NULL`, returns up to 3 existing
+observations above a conservative similarity threshold, and surfaces
+them on the response:
+
+```json
+{
+  "entity_id": 42,
+  "observation_id": 999,
+  "stored": true,
+  "possible_conflicts": [
+    {"observation_id": 877, "similarity": 0.87, "snippet": "..."},
+    {"observation_id": 801, "similarity": 0.62, "snippet": "..."}
+  ]
+}
+```
+
+The agent decides whether to call `forget(observation_id)` on each.
+The backend never soft-deletes on the agent's behalf.
+
+The similarity threshold is **intentionally not pinned in this
+decision**. Its calibration is a follow-up job for the telemetry loop
+described below: we ship with a conservative starting value, observe
+`conflicts_surfaced` vs `conflicts_acted_on`, and freeze the number
+when the data supports a defensible choice. Pinning a threshold at
+design time without production evidence would contradict the
+"evidence over intuition" principle in the PITCH.
+
+One new line in the recommended LLM instructions:
+
+> *"If `remember` returns `possible_conflicts`, review those
+> observations and call `forget(obs_id)` on any your new fact
+> supersedes."*
+
+Telemetry is extended to close the loop:
+`conflicts_surfaced INTEGER` is added to `tool_calls`, and
+`conflicts_acted_on` is derived post-hoc by joining `forget` calls
+against surfaced observation IDs within a short window. These
+measurements are what eventually pin the threshold and validate
+that the hint is changing agent behavior; they also let us back the
+feature out cleanly if the surface-to-act ratio stays low.
+
+No new MCP tool. No schema change on `observations` / `entities`.
+No change to `forget` semantics. Response shape extends additively;
+clients that ignore the new field are unaffected.
+
+### Rationale
+
+- **Empirical motivation, not speculative.** 100% silent-overwrite
+  rate in 8 days of real usage across `claude-code` on `workmem`,
+  `inv-try`, `governor`, and global scope. Direction is unambiguous;
+  sample is small enough to leave threshold and copy tunable.
+- **Preserves the ontological commitment.** Backend detects; agent
+  decides. `forget` remains the only mutation mechanism for the
+  canonical state. No "superseded" state, no supersession chain, no
+  diary semantics.
+- **Preserves "12 tools, no more no less."** The feature fits inside
+  the existing `remember` surface. No tool 13.
+- **Preserves the single-binary / pure-Go / CGO_ENABLED=0 invariants.**
+  Detection reuses the FTS-based composite ranker already in
+  `internal/store/search.go`. No embedding model, no external runtime.
+- **Honest about its limits.** Lexical similarity catches
+  reformulations with high token overlap ("rate limit 100/min" vs
+  "rate limit 200/min") and misses semantic contradictions with no
+  overlap ("limit is 100" vs "we accept up to one hundred").
+  Documented as a hint, not a guarantee. The agent can still call
+  `recall_entity` proactively in paranoid contexts.
+- **Measurable.** `conflicts_surfaced` + `conflicts_acted_on` turn
+  the feature into a telemetry-observable control loop. The threshold
+  is calibrated, not declared, and the feature can be reverted on
+  evidence.
+
+### Alternatives considered
+
+- **Auto-supersede: backend soft-deletes high-similarity existing
+  observations without notifying the agent.** Rejected. Similarity is
+  not contradiction (complementary facts like "uses Binance" / "uses
+  Bitfinex" share tokens), so auto-delete destroys data. It also
+  violates the invariant that `forget` is the only mutation mechanism,
+  granting the backend semantic authority it should not have. And it
+  leaves no audit trail — a later `recall_entity` short of expected
+  rows has no explanation.
+
+- **Prompt reinforcement: instruct the agent to `recall_entity` before
+  every `remember`.** Rejected. Violates "stupidity of use": the agent
+  should not have to detect conflicts, and should not pay a read cost
+  on every write. The telemetry shows the current prompt guidance is
+  already ignored in 14/14 cases; adding more text is unlikely to fix
+  what a structural signal can.
+
+- **Introduce a `supersede(old_id, new_content)` tool.** Rejected.
+  Breaches the 12-tool ceiling. Duplicates semantics already
+  expressible as `forget` + `remember`. Invites a supersession-chain
+  schema (the diary model this project is explicitly not).
+
+- **Semantic embedding-based conflict detection.** Rejected for this
+  iteration. Breaks the pure-Go single-binary invariant (ONNX runtime,
+  Ollama call, or external API — all compromises). Lexical similarity
+  via the existing composite ranker covers the high-overlap case for
+  free. Revisit if the telemetry says the lexical layer is missing
+  too many real conflicts *and* a pure-Go inference path is
+  available.
+
+- **Pin the similarity threshold now.** Rejected. The whole point of
+  the telemetry instrumentation is to calibrate the threshold on
+  production evidence. A design-time number would either be too
+  aggressive (noise) or too conservative (no signal) without data to
+  tell us which, and would lock us into the wrong value harder than a
+  number explicitly marked as provisional.
+
+- **Defer the decision pending more data.** Rejected. The 100%
+  silent-overwrite ratio across 14 transitions is already a
+  directional signal strong enough to ship a conservative, reversible
+  change. Waiting increases the accumulated wrong state in live DBs
+  without producing a qualitatively different answer.
+
 ## 2026-04-14: Ship encrypted backup as a subcommand; leave restore as plain `age -d`
 
 ### Context

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -131,7 +131,7 @@ Evolve workmem beyond Node parity. Each step is motivated by telemetry
 evidence, not speculation, and every step ships a measurement path so
 its own effectiveness becomes observable.
 
-### Step 4.1: Conflict hints in `remember` response [⏸]
+### Step 4.1: Conflict hints in `remember` response [🔧]
 
 Surface same-entity near-duplicate observations when the agent calls
 `remember`, so supersession-as-forget becomes observable from the
@@ -146,32 +146,34 @@ high-similarity writes; telemetry records `conflicts_surfaced` per
 fixture demonstrates the end-to-end loop (write → hint → forget →
 clean recall).
 
-- [ ] Implement scoped composite-ranker conflict detection in the
+- [x] Implement scoped composite-ranker conflict detection in the
   Remember path (reuse ranking logic from `internal/store/search.go`,
   scoped to `entity_id = E AND deleted_at IS NULL`)
-- [ ] Extend `remember` response shape with optional
+- [x] Extend `remember` response shape with optional
   `possible_conflicts` array (observation_id, similarity, snippet)
-- [ ] Add a conservative starting similarity threshold as a named
+- [x] Add a conservative starting similarity threshold as a named
   constant; document it as provisional and note that its final value
   is pinned via telemetry observation
-- [ ] Add `conflicts_surfaced INTEGER` column to `tool_calls` schema
+- [x] Add `conflicts_surfaced INTEGER` column to `tool_calls` schema
   in `internal/telemetry/schema.go` with an idempotent ALTER path for
   existing DBs
-- [ ] Wire the `conflicts_surfaced` count from the Remember result
+- [x] Wire the `conflicts_surfaced` count from the Remember result
   into `LogToolCall` in `internal/mcpserver/telemetry.go`
-- [ ] Update MCP tool registration so the `remember` output schema
-  exposes the new field (additive, backward-compatible)
-- [ ] Unit tests: detection finds known duplicates, respects
+- [x] Update MCP tool registration so the `remember` output schema
+  exposes the new field (additive, backward-compatible; struct JSON
+  tags + omitempty carry the shape, consistent with the repo's
+  existing pattern of no explicit OutputSchema)
+- [x] Unit tests: detection finds known duplicates, respects
   threshold, respects entity scope (different entity = no conflict),
   respects tombstones (deleted observations are not surfaced)
-- [ ] Integration test over MCP stdio: `remember` returns hints,
+- [x] Integration test over MCP stdio: `remember` returns hints,
   agent-simulated `forget` on a surfaced ID removes it, subsequent
-  `recall` is clean
-- [ ] Update `API_CONTRACT.md` with the new response field and an
+  `recall` is clean (`TestStepGateConflictHintEndToEndLoop`)
+- [x] Update `API_CONTRACT.md` with the new response field and an
   explicit note that `forget` semantics are unchanged
-- [ ] Update README recommended LLM instructions with the one-line
+- [x] Update README recommended LLM instructions with the one-line
   guidance about `possible_conflicts`
-- [ ] Extend `analysis/telemetry.py` with a cell that plots
+- [x] Extend `analysis/telemetry.py` with a cell that plots
   `conflicts_surfaced` vs `conflicts_acted_on` over time, so threshold
   calibration has a dashboard
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -124,3 +124,59 @@ Port the Node telemetry design to Go with Go-native refinements and a new privac
 - [x] Telemetry invariants wired into `OPERATIONS.md`
 
 **On Step Gate (all items [x]):** trigger correctness review on telemetry hook points and strict-mode hashing.
+
+## Phase 4: Behavioral refinements [🔧]
+
+Evolve workmem beyond Node parity. Each step is motivated by telemetry
+evidence, not speculation, and every step ships a measurement path so
+its own effectiveness becomes observable.
+
+### Step 4.1: Conflict hints in `remember` response [⏸]
+
+Surface same-entity near-duplicate observations when the agent calls
+`remember`, so supersession-as-forget becomes observable from the
+agent's point of view. Full rationale and telemetry evidence
+(14/14 silent overwrites in the first 8 days of production data) in
+`DECISION_LOG.md` under 2026-04-22.
+
+**Gate:** `remember` returns `possible_conflicts` on same-entity
+high-similarity writes; telemetry records `conflicts_surfaced` per
+`remember` call and `conflicts_acted_on` is derivable post-hoc from
+`forget` calls against surfaced observation IDs; an integration
+fixture demonstrates the end-to-end loop (write → hint → forget →
+clean recall).
+
+- [ ] Implement scoped composite-ranker conflict detection in the
+  Remember path (reuse ranking logic from `internal/store/search.go`,
+  scoped to `entity_id = E AND deleted_at IS NULL`)
+- [ ] Extend `remember` response shape with optional
+  `possible_conflicts` array (observation_id, similarity, snippet)
+- [ ] Add a conservative starting similarity threshold as a named
+  constant; document it as provisional and note that its final value
+  is pinned via telemetry observation
+- [ ] Add `conflicts_surfaced INTEGER` column to `tool_calls` schema
+  in `internal/telemetry/schema.go` with an idempotent ALTER path for
+  existing DBs
+- [ ] Wire the `conflicts_surfaced` count from the Remember result
+  into `LogToolCall` in `internal/mcpserver/telemetry.go`
+- [ ] Update MCP tool registration so the `remember` output schema
+  exposes the new field (additive, backward-compatible)
+- [ ] Unit tests: detection finds known duplicates, respects
+  threshold, respects entity scope (different entity = no conflict),
+  respects tombstones (deleted observations are not surfaced)
+- [ ] Integration test over MCP stdio: `remember` returns hints,
+  agent-simulated `forget` on a surfaced ID removes it, subsequent
+  `recall` is clean
+- [ ] Update `API_CONTRACT.md` with the new response field and an
+  explicit note that `forget` semantics are unchanged
+- [ ] Update README recommended LLM instructions with the one-line
+  guidance about `possible_conflicts`
+- [ ] Extend `analysis/telemetry.py` with a cell that plots
+  `conflicts_surfaced` vs `conflicts_acted_on` over time, so threshold
+  calibration has a dashboard
+
+**On Step Gate (all items [x]):** trigger tripartite review +
+Integration Pulse. Review focus points: the scoped detection must not
+leak into global ranking; the telemetry additions must preserve the
+opt-in invariant (`MEMORY_TELEMETRY_PATH` unset ⇒ zero overhead); the
+new response field must not break existing clients that ignore it.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -23,6 +23,17 @@
 
 ### P1
 
+- Conflict-hint threshold (`conflictHintMinScore = 0.6` in `internal/store/conflict.go`) is provisional and must be calibrated against production telemetry. DECISION_LOG 2026-04-22 commits to "evidence over intuition" for this value — the constant lives unchanged until the calibration protocol below produces a defensible choice.
+Trigger: The threshold is treated as permanent, or tuned on vibes instead of the telemetry ratio.
+Blast radius: Too low → noisy hints, agent ignores them, surface-to-act ratio collapses, feature silently dies. Too high → real conflicts stop surfacing, silent-overwrite rate rises back toward the 14/14 baseline.
+Fix (calibration protocol):
+  1. Sample window: at least 200 `remember` calls across ≥ 2 active projects, or 4 weeks of real use, whichever comes first. Re-run `analysis/telemetry.py` cell 7b at the end of the window.
+  2. Health signal: surface-to-act ratio ≥ 0.5 sustained means the hint is landing. < 0.2 means it is being ignored.
+  3. Distribution check: inspect the raw similarity scores of surfaced hints that were NOT acted on. If they cluster near the threshold, the threshold is too low. If they span the full range, the prompt line or agent discipline is the bottleneck, not the threshold.
+  4. Adjust in 0.05 increments, one change per cycle. Record the change in DECISION_LOG as an append-only entry with the evidence summary.
+  5. After adjustment, reset the sample window and re-measure.
+Done when: either the threshold has been confirmed twice in a row at the same value with the ratio inside [0.5, 0.9], or telemetry has shown a clear reason to redesign the hint (e.g., lexical detection consistently misses semantic conflicts and a pure-Go embedding path becomes available).
+
 - The Go port now replays the shared product fixtures locally, but still lacks an automated Node-vs-Go dual-runtime comparison in CI.
 Trigger: Trusting Go-only fixture replay as full parity proof.
 Blast radius: Drift from the JS reference can sneak in when both sides evolve independently.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ You have access to a persistent memory store. Use it proactively:
 - **`forget`** to remove stale or incorrect facts
 - **`relate`** to link entities with named relationships
 
+If `remember` returns `possible_conflicts`, review those observations
+and call `forget(obs_id)` on any your new fact supersedes.
+
 Remember: preferences, corrections, names, decisions, conventions.
 Don't remember: transient tasks, code snippets, things already in docs/git.
 ```

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os/exec"
 	"path/filepath"
@@ -131,6 +132,123 @@ func TestServerListsToolsAndCallsBackend(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("runtime.Run() did not exit after client shutdown")
 	}
+}
+
+func TestServerRememberSurfacesPossibleConflicts(t *testing.T) {
+	runtime, err := New(Config{DBPath: t.TempDir() + "/memory.db"})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runtime.Run(ctx, serverTransport)
+	}()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "conflict-hint-test", Version: "1.0.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() error = %v", err)
+	}
+	defer session.Close()
+
+	first, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "remember",
+		Arguments: map[string]any{
+			"entity":      "API",
+			"observation": "rate limit is 100 per minute",
+		},
+	})
+	if err != nil {
+		t.Fatalf("session.CallTool(remember seed) error = %v", err)
+	}
+	if first.IsError {
+		t.Fatalf("remember seed unexpectedly returned an error: %#v", first)
+	}
+	firstPayload := rememberTextPayload(t, first)
+	if _, present := firstPayload["possible_conflicts"]; present {
+		t.Fatalf("seed write returned possible_conflicts; expected the field to be omitted on first-ever observation: %v", firstPayload)
+	}
+	seedObsID, ok := firstPayload["observation_id"].(float64)
+	if !ok {
+		t.Fatalf("seed payload observation_id missing or not a number: %#v", firstPayload["observation_id"])
+	}
+
+	second, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "remember",
+		Arguments: map[string]any{
+			"entity":      "API",
+			"observation": "rate limit is 200 per minute",
+		},
+	})
+	if err != nil {
+		t.Fatalf("session.CallTool(remember follow-up) error = %v", err)
+	}
+	if second.IsError {
+		t.Fatalf("remember follow-up unexpectedly returned an error: %#v", second)
+	}
+	followPayload := rememberTextPayload(t, second)
+	rawHints, present := followPayload["possible_conflicts"]
+	if !present {
+		t.Fatalf("follow-up write missing possible_conflicts on near-duplicate content: %v", followPayload)
+	}
+	hints, ok := rawHints.([]any)
+	if !ok {
+		t.Fatalf("possible_conflicts expected array, got %T: %v", rawHints, rawHints)
+	}
+	if len(hints) == 0 {
+		t.Fatalf("possible_conflicts present but empty; expected at least one hint")
+	}
+	firstHint, ok := hints[0].(map[string]any)
+	if !ok {
+		t.Fatalf("possible_conflicts[0] expected object, got %T", hints[0])
+	}
+	for _, field := range []string{"observation_id", "similarity", "snippet"} {
+		if _, has := firstHint[field]; !has {
+			t.Fatalf("possible_conflicts[0] missing field %q: %v", field, firstHint)
+		}
+	}
+	hintObsID, ok := firstHint["observation_id"].(float64)
+	if !ok {
+		t.Fatalf("hint observation_id not a number: %#v", firstHint["observation_id"])
+	}
+	if hintObsID != seedObsID {
+		t.Fatalf("hint observation_id = %v, want seed %v", hintObsID, seedObsID)
+	}
+
+	if err := session.Close(); err != nil {
+		t.Fatalf("session.Close() error = %v", err)
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("runtime.Run() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runtime.Run() did not exit after client shutdown")
+	}
+}
+
+func rememberTextPayload(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatalf("tool result has no content: %#v", result)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected text content, got %T", result.Content[0])
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(text.Text), &payload); err != nil {
+		t.Fatalf("unmarshal tool result text: %v\npayload: %s", err, text.Text)
+	}
+	return payload
 }
 
 func TestServerCommandTransportSmoke(t *testing.T) {

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -2,7 +2,6 @@ package mcpserver
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"os/exec"
 	"path/filepath"
@@ -169,7 +168,7 @@ func TestServerRememberSurfacesPossibleConflicts(t *testing.T) {
 	if first.IsError {
 		t.Fatalf("remember seed unexpectedly returned an error: %#v", first)
 	}
-	firstPayload := rememberTextPayload(t, first)
+	firstPayload := unmarshalToolText(t, first)
 	if _, present := firstPayload["possible_conflicts"]; present {
 		t.Fatalf("seed write returned possible_conflicts; expected the field to be omitted on first-ever observation: %v", firstPayload)
 	}
@@ -191,7 +190,7 @@ func TestServerRememberSurfacesPossibleConflicts(t *testing.T) {
 	if second.IsError {
 		t.Fatalf("remember follow-up unexpectedly returned an error: %#v", second)
 	}
-	followPayload := rememberTextPayload(t, second)
+	followPayload := unmarshalToolText(t, second)
 	rawHints, present := followPayload["possible_conflicts"]
 	if !present {
 		t.Fatalf("follow-up write missing possible_conflicts on near-duplicate content: %v", followPayload)
@@ -233,22 +232,6 @@ func TestServerRememberSurfacesPossibleConflicts(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("runtime.Run() did not exit after client shutdown")
 	}
-}
-
-func rememberTextPayload(t *testing.T, result *mcp.CallToolResult) map[string]any {
-	t.Helper()
-	if len(result.Content) == 0 {
-		t.Fatalf("tool result has no content: %#v", result)
-	}
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected text content, got %T", result.Content[0])
-	}
-	var payload map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &payload); err != nil {
-		t.Fatalf("unmarshal tool result text: %v\npayload: %s", err, text.Text)
-	}
-	return payload
 }
 
 func TestServerCommandTransportSmoke(t *testing.T) {

--- a/internal/mcpserver/telemetry.go
+++ b/internal/mcpserver/telemetry.go
@@ -67,15 +67,29 @@ func (r *Runtime) logToolCall(
 		projectPath = resolveProjectPath(projectRaw)
 	}
 	return tele.LogToolCall(telemetry.ToolCallInput{
-		Tool:          toolName,
-		Client:        detectClient(req),
-		DBScope:       dbScope,
-		ProjectPath:   projectPath,
-		DurationMs:    float64(elapsed) / float64(time.Millisecond),
-		ArgsSummary:   telemetry.SanitizeArgs(argObject, tele.Strict()),
-		ResultSummary: telemetry.SummarizeResult(result),
-		IsError:       isError,
+		Tool:              toolName,
+		Client:            detectClient(req),
+		DBScope:           dbScope,
+		ProjectPath:       projectPath,
+		DurationMs:        float64(elapsed) / float64(time.Millisecond),
+		ArgsSummary:       telemetry.SanitizeArgs(argObject, tele.Strict()),
+		ResultSummary:     telemetry.SummarizeResult(result),
+		IsError:           isError,
+		ConflictsSurfaced: conflictsSurfacedCount(result),
 	})
+}
+
+// conflictsSurfacedCount returns the number of possible_conflicts hints
+// attached to a remember result, or 0 for every other tool and for
+// remember calls that produced no hints. Lives here rather than in
+// telemetry/ because the knowledge that only RememberResult carries the
+// field belongs to the dispatch layer, not to the sink.
+func conflictsSurfacedCount(result any) int {
+	remember, ok := result.(store.RememberResult)
+	if !ok {
+		return 0
+	}
+	return len(remember.PossibleConflicts)
 }
 
 // logSearchMetrics mirrors the recall search_metrics row. No-op when the

--- a/internal/mcpserver/telemetry_integration_test.go
+++ b/internal/mcpserver/telemetry_integration_test.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -229,6 +230,201 @@ func TestTelemetryStrictModeHashesIdentifiersEndToEnd(t *testing.T) {
 	if !strings.HasPrefix(smQuery.String, "sha256:") {
 		t.Fatalf("strict search_metrics.query not hashed: %q", smQuery.String)
 	}
+}
+
+// TestStepGateConflictHintEndToEndLoop is the Step 4.1 Gate fixture.
+// It drives the full conflict-hint loop through the MCP stdio surface
+// in-process and asserts every part of the promised behavior lands:
+//
+//  1. a seed `remember` produces no hints
+//  2. a near-duplicate `remember` surfaces possible_conflicts referencing
+//     the seed observation
+//  3. `forget` on the hinted observation_id soft-deletes it
+//  4. subsequent `recall` returns only the surviving observation
+//     (FTS + ranking both respect the tombstone)
+//  5. telemetry rows reflect conflicts_surfaced = {0, >=1, 0, 0} in order
+func TestStepGateConflictHintEndToEndLoop(t *testing.T) {
+	telePath := filepath.Join(t.TempDir(), "step-gate.db")
+	tele := telemetry.InitIfEnabled(telePath, false)
+	if tele == nil {
+		t.Fatalf("telemetry InitIfEnabled returned nil")
+	}
+
+	runtime, err := New(Config{DBPath: filepath.Join(t.TempDir(), "memory.db"), Telemetry: tele})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	session, stop := startTelemetrySession(t, runtime)
+	defer stop()
+	ctx := context.Background()
+
+	// Step 1 — seed observation; no hints expected.
+	seedResult, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "remember",
+		Arguments: map[string]any{
+			"entity":      "API",
+			"observation": "rate limit is 100 per minute",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seed remember: %v", err)
+	}
+	if seedResult.IsError {
+		t.Fatalf("seed remember tool error: %#v", seedResult)
+	}
+	seedPayload := unmarshalToolText(t, seedResult)
+	if _, present := seedPayload["possible_conflicts"]; present {
+		t.Fatalf("seed remember surfaced possible_conflicts; expected none")
+	}
+	seedObsID, ok := seedPayload["observation_id"].(float64)
+	if !ok {
+		t.Fatalf("seed observation_id not a number: %#v", seedPayload["observation_id"])
+	}
+
+	// Step 2 — near-duplicate; hint must reference the seed observation.
+	followResult, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "remember",
+		Arguments: map[string]any{
+			"entity":      "API",
+			"observation": "rate limit is 200 per minute",
+		},
+	})
+	if err != nil {
+		t.Fatalf("follow-up remember: %v", err)
+	}
+	if followResult.IsError {
+		t.Fatalf("follow-up remember tool error: %#v", followResult)
+	}
+	followPayload := unmarshalToolText(t, followResult)
+	rawHints, present := followPayload["possible_conflicts"]
+	if !present {
+		t.Fatalf("follow-up remember missing possible_conflicts: %v", followPayload)
+	}
+	hints, ok := rawHints.([]any)
+	if !ok || len(hints) == 0 {
+		t.Fatalf("possible_conflicts not a non-empty array: %#v", rawHints)
+	}
+	hint := hints[0].(map[string]any)
+	hintObsID, ok := hint["observation_id"].(float64)
+	if !ok {
+		t.Fatalf("hint observation_id not a number: %#v", hint["observation_id"])
+	}
+	if hintObsID != seedObsID {
+		t.Fatalf("hint observation_id = %v, want seed %v", hintObsID, seedObsID)
+	}
+
+	// Step 3 — forget the hinted observation.
+	forgetResult, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "forget",
+		Arguments: map[string]any{
+			"observation_id": seedObsID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("forget: %v", err)
+	}
+	if forgetResult.IsError {
+		t.Fatalf("forget tool error: %#v", forgetResult)
+	}
+	forgetPayload := unmarshalToolText(t, forgetResult)
+	if deleted, _ := forgetPayload["deleted"].(bool); !deleted {
+		t.Fatalf("forget deleted = false, want true: %v", forgetPayload)
+	}
+
+	// Step 4 — recall must return only the surviving observation, and the
+	// forgotten one must not appear anywhere in the text content (which
+	// covers both FTS and ranking paths since recall joins them).
+	recallResult, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "recall",
+		Arguments: map[string]any{
+			"query": "rate limit per minute",
+			"limit": 10,
+		},
+	})
+	if err != nil {
+		t.Fatalf("recall: %v", err)
+	}
+	if recallResult.IsError {
+		t.Fatalf("recall tool error: %#v", recallResult)
+	}
+	text := toolTextContent(t, recallResult)
+	if strings.Contains(text, "rate limit is 100 per minute") {
+		t.Fatalf("recall returned the tombstoned observation: %s", text)
+	}
+	if !strings.Contains(text, "rate limit is 200 per minute") {
+		t.Fatalf("recall missing the surviving observation: %s", text)
+	}
+
+	// Step 5 — read telemetry back. Runtime.Close (via stop) flushes the
+	// sink; see the ownership contract in mcpserver.Config.
+	stop()
+
+	rdb, err := sql.Open("sqlite", "file:"+filepath.Clean(telePath)+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("open telemetry db: %v", err)
+	}
+	defer rdb.Close()
+
+	rows, err := rdb.Query(`SELECT tool, conflicts_surfaced FROM tool_calls ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query tool_calls: %v", err)
+	}
+	defer rows.Close()
+	type row struct {
+		tool              string
+		conflictsSurfaced int
+	}
+	var got []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.tool, &r.conflictsSurfaced); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, r)
+	}
+	wantTools := []string{"remember", "remember", "forget", "recall"}
+	if len(got) != len(wantTools) {
+		t.Fatalf("tool_calls count = %d, want %d; rows=%+v", len(got), len(wantTools), got)
+	}
+	for i, want := range wantTools {
+		if got[i].tool != want {
+			t.Fatalf("row[%d].tool = %q, want %q", i, got[i].tool, want)
+		}
+	}
+	if got[0].conflictsSurfaced != 0 {
+		t.Fatalf("seed remember conflicts_surfaced = %d, want 0", got[0].conflictsSurfaced)
+	}
+	if got[1].conflictsSurfaced < 1 {
+		t.Fatalf("follow-up remember conflicts_surfaced = %d, want >=1", got[1].conflictsSurfaced)
+	}
+	if got[2].conflictsSurfaced != 0 {
+		t.Fatalf("forget conflicts_surfaced = %d, want 0", got[2].conflictsSurfaced)
+	}
+	if got[3].conflictsSurfaced != 0 {
+		t.Fatalf("recall conflicts_surfaced = %d, want 0", got[3].conflictsSurfaced)
+	}
+}
+
+func unmarshalToolText(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(toolTextContent(t, result)), &payload); err != nil {
+		t.Fatalf("unmarshal tool text: %v", err)
+	}
+	return payload
+}
+
+func toolTextContent(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatalf("tool result has no content: %#v", result)
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected text content, got %T", result.Content[0])
+	}
+	return text.Text
 }
 
 func TestTelemetryLogsConflictsSurfacedOnRememberWithHints(t *testing.T) {

--- a/internal/mcpserver/telemetry_integration_test.go
+++ b/internal/mcpserver/telemetry_integration_test.go
@@ -231,6 +231,81 @@ func TestTelemetryStrictModeHashesIdentifiersEndToEnd(t *testing.T) {
 	}
 }
 
+func TestTelemetryLogsConflictsSurfacedOnRememberWithHints(t *testing.T) {
+	telePath := filepath.Join(t.TempDir(), "conflicts-surfaced.db")
+	tele := telemetry.InitIfEnabled(telePath, false)
+	if tele == nil {
+		t.Fatalf("telemetry InitIfEnabled returned nil")
+	}
+
+	runtime, err := New(Config{DBPath: filepath.Join(t.TempDir(), "memory.db"), Telemetry: tele})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	session, stop := startTelemetrySession(t, runtime)
+	defer stop()
+	ctx := context.Background()
+
+	// Seed an observation, then a near-duplicate on the same entity so
+	// the second remember produces at least one possible_conflicts hint
+	// and the telemetry row for that second call records the count.
+	callOK(t, session, ctx, "remember", map[string]any{
+		"entity":      "API",
+		"observation": "rate limit is 100 per minute",
+	})
+	callOK(t, session, ctx, "remember", map[string]any{
+		"entity":      "API",
+		"observation": "rate limit is 200 per minute",
+	})
+	// An unrelated tool whose telemetry row should always show 0
+	// conflicts_surfaced regardless of prior remember calls.
+	callOK(t, session, ctx, "recall", map[string]any{
+		"query": "API",
+		"limit": 5,
+	})
+
+	stop()
+
+	rdb, err := sql.Open("sqlite", "file:"+filepath.Clean(telePath)+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("open telemetry db: %v", err)
+	}
+	defer rdb.Close()
+
+	rows, err := rdb.Query(`SELECT tool, conflicts_surfaced FROM tool_calls ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query tool_calls: %v", err)
+	}
+	defer rows.Close()
+
+	type row struct {
+		tool              string
+		conflictsSurfaced int
+	}
+	var got []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.tool, &r.conflictsSurfaced); err != nil {
+			t.Fatalf("scan row: %v", err)
+		}
+		got = append(got, r)
+	}
+	if len(got) != 3 {
+		t.Fatalf("tool_calls count = %d, want 3", len(got))
+	}
+
+	if got[0].tool != "remember" || got[0].conflictsSurfaced != 0 {
+		t.Fatalf("row[0] = %+v; want seed remember with conflicts_surfaced=0", got[0])
+	}
+	if got[1].tool != "remember" || got[1].conflictsSurfaced < 1 {
+		t.Fatalf("row[1] = %+v; want follow-up remember with conflicts_surfaced>=1", got[1])
+	}
+	if got[2].tool != "recall" || got[2].conflictsSurfaced != 0 {
+		t.Fatalf("row[2] = %+v; want recall with conflicts_surfaced=0", got[2])
+	}
+}
+
 func callOK(t *testing.T, session *mcp.ClientSession, ctx context.Context, name string, args map[string]any) {
 	t.Helper()
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})

--- a/internal/store/conflict.go
+++ b/internal/store/conflict.go
@@ -25,9 +25,9 @@ const conflictHintMinScore = 0.6
 // conflictHintMaxResults caps the number of hints surfaced per remember.
 const conflictHintMaxResults = 3
 
-// conflictHintSnippetLength matches the default compact recall snippet so
-// hints and compact recall output read consistently.
-const conflictHintSnippetLength = 120
+// (Snippet length is derived at call time from the same
+// compactSnippetLength() helper compact recall uses, so `COMPACT_SNIPPET_LENGTH`
+// env overrides apply uniformly across both surfaces. No separate constant.)
 
 // DetectEntityConflicts scans non-deleted observations attached to entityID
 // and returns up to conflictHintMaxResults that resemble content above the
@@ -72,7 +72,7 @@ func DetectEntityConflicts(db *sql.DB, entityID int64, content string) ([]Confli
 		if obs.CompositeScore < conflictHintMinScore {
 			continue
 		}
-		snippet, _ := compactContent(obs.Content, true, conflictHintSnippetLength)
+		snippet, _ := compactContent(obs.Content, true, compactSnippetLength())
 		hints = append(hints, ConflictHint{
 			ObservationID: obs.ID,
 			Similarity:    obs.CompositeScore,
@@ -102,6 +102,14 @@ func collectEntityScopedCandidates(db *sql.DB, entityID int64, content string) (
 	if len(cleanTerms) == 0 {
 		return candidates, nil
 	}
+
+	// FTS error handling note: both FTS channels silence Query errors via
+	// `if err == nil`, mirroring the pattern in search.go so conflict
+	// detection degrades the same way recall does when the FTS layer is
+	// unavailable. The calibration consequence is that an FTS outage shows
+	// up in telemetry as a run of `conflicts_surfaced = 0` rather than as
+	// errors — review the surface-to-act ratio in light of any known FTS
+	// incident before pinning thresholds from that period.
 
 	// fts_phrase — full phrase, only meaningful with multiple terms.
 	if len(cleanTerms) > 1 {

--- a/internal/store/conflict.go
+++ b/internal/store/conflict.go
@@ -1,0 +1,156 @@
+package store
+
+import (
+	"database/sql"
+	"strings"
+)
+
+// ConflictHint describes an existing observation on the same entity whose
+// lexical similarity to a new content exceeds the conflict threshold.
+// Surfaced on `remember` responses so the agent can decide whether to
+// `forget` the prior fact. See DECISION_LOG 2026-04-22.
+type ConflictHint struct {
+	ObservationID int64   `json:"observation_id"`
+	Similarity    float64 `json:"similarity"`
+	Snippet       string  `json:"snippet"`
+}
+
+// conflictHintMinScore is the minimum composite similarity for an existing
+// observation to qualify as a possible conflict. Intentionally conservative
+// at launch — calibrated via telemetry (DECISION_LOG 2026-04-22). Tuning
+// this value is implementation-internal and does not constitute a contract
+// change.
+const conflictHintMinScore = 0.6
+
+// conflictHintMaxResults caps the number of hints surfaced per remember.
+const conflictHintMaxResults = 3
+
+// conflictHintSnippetLength matches the default compact recall snippet so
+// hints and compact recall output read consistently.
+const conflictHintSnippetLength = 120
+
+// DetectEntityConflicts scans non-deleted observations attached to entityID
+// and returns up to conflictHintMaxResults that resemble content above the
+// conflict threshold. Read-only — does not touch access counts, does not
+// modify state, does not emit telemetry.
+//
+// The detector reuses the composite ranker's lexical channels (fts_phrase,
+// fts, content_like) scoped to entity_id = entityID. Entity-identity and
+// event-based channels are skipped because they are constant or irrelevant
+// inside a single entity.
+//
+// Callers should invoke this BEFORE inserting the new observation so that
+// self-match filtering is unnecessary.
+func DetectEntityConflicts(db *sql.DB, entityID int64, content string) ([]ConflictHint, error) {
+	trimmed := strings.TrimSpace(content)
+	if entityID <= 0 || trimmed == "" {
+		return nil, nil
+	}
+
+	candidates, err := collectEntityScopedCandidates(db, entityID, trimmed)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	hydrated, err := HydrateCandidates(db, candidates)
+	if err != nil {
+		return nil, err
+	}
+	if len(hydrated) == 0 {
+		return nil, nil
+	}
+
+	// Preserve every candidate through scoring so we can threshold-filter
+	// next. Passing len(hydrated) as the limit means no truncation here.
+	ranked := ScoreCandidates(hydrated, candidates, memoryHalfLifeWeeks(), len(hydrated))
+
+	hints := make([]ConflictHint, 0, conflictHintMaxResults)
+	for _, obs := range ranked {
+		if obs.CompositeScore < conflictHintMinScore {
+			continue
+		}
+		snippet, _ := compactContent(obs.Content, true, conflictHintSnippetLength)
+		hints = append(hints, ConflictHint{
+			ObservationID: obs.ID,
+			Similarity:    obs.CompositeScore,
+			Snippet:       snippet,
+		})
+		if len(hints) >= conflictHintMaxResults {
+			break
+		}
+	}
+	return hints, nil
+}
+
+// collectEntityScopedCandidates runs fts_phrase, fts, and content_like
+// channels against observations belonging to a single entity. Mirrors
+// CollectCandidates in search.go but with a tighter scope and fewer
+// channels — entity-identity and event-based channels are skipped as
+// they are constant or irrelevant inside a single entity.
+func collectEntityScopedCandidates(db *sql.DB, entityID int64, content string) (map[int64]*candidate, error) {
+	candidates := map[int64]*candidate{}
+	const (
+		maxCandidates = 50
+		collectLimit  = 20
+	)
+
+	terms := strings.Fields(content)
+	cleanTerms := stripQuotes(terms)
+	if len(cleanTerms) == 0 {
+		return candidates, nil
+	}
+
+	// fts_phrase — full phrase, only meaningful with multiple terms.
+	if len(cleanTerms) > 1 {
+		phraseQuery := `"` + strings.Join(cleanTerms, " ") + `"`
+		rows, err := db.Query(`
+			SELECT memory_fts.rowid, memory_fts.rank
+			FROM memory_fts
+			JOIN observations o ON o.id = memory_fts.rowid
+			WHERE memory_fts MATCH ? AND o.entity_id = ? AND o.deleted_at IS NULL
+			ORDER BY memory_fts.rank LIMIT ?
+		`, phraseQuery, entityID, collectLimit)
+		if err == nil {
+			if err := collectFTSRows(rows, candidates, "fts_phrase", maxCandidates); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// fts — any term.
+	ftsQuery := strings.Join(quoteTerms(cleanTerms), " OR ")
+	if ftsQuery != "" {
+		rows, err := db.Query(`
+			SELECT memory_fts.rowid, memory_fts.rank
+			FROM memory_fts
+			JOIN observations o ON o.id = memory_fts.rowid
+			WHERE memory_fts MATCH ? AND o.entity_id = ? AND o.deleted_at IS NULL
+			ORDER BY memory_fts.rank LIMIT ?
+		`, ftsQuery, entityID, collectLimit)
+		if err == nil {
+			if err := collectFTSRows(rows, candidates, "fts", maxCandidates); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// content_like — scoped substring per term, catches reformulations FTS
+	// tokenization may have missed.
+	for _, term := range cleanTerms {
+		if len(candidates) >= maxCandidates {
+			break
+		}
+		if err := collectSimpleIDs(db, candidates, maxCandidates, "content_like", `
+			SELECT o.id FROM observations o
+			WHERE o.entity_id = ? AND o.deleted_at IS NULL AND o.content LIKE ?
+			ORDER BY o.id LIMIT ?
+		`, entityID, "%"+term+"%", collectLimit); err != nil {
+			return nil, err
+		}
+	}
+
+	return candidates, nil
+}

--- a/internal/store/conflict_test.go
+++ b/internal/store/conflict_test.go
@@ -135,21 +135,43 @@ func TestDetectEntityConflicts_CapsAtMaxResults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpsertEntity: %v", err)
 	}
-	for i := range 5 {
-		if _, err := AddObservation(db, entityID, "rate limit is 100 per minute", "user", 1.0); err != nil {
+	// Five DISTINCT near-duplicates: AddObservation dedupes by exact
+	// `entity_id + content` match (see sqlite.go), so seeding five copies
+	// of the same string would leave only one row in the DB and make the
+	// cap assertion vacuous. Each string must be unique but lexically
+	// similar enough to all score above the conflict threshold.
+	priorContents := []string{
+		"rate limit is 100 per minute",
+		"rate limit is 150 per minute",
+		"rate limit is 250 per minute",
+		"rate limit is 300 per minute",
+		"rate limit is 500 per minute",
+	}
+	seeded := make([]int64, 0, len(priorContents))
+	for i, content := range priorContents {
+		id, err := AddObservation(db, entityID, content, "user", 1.0)
+		if err != nil {
 			t.Fatalf("AddObservation[%d]: %v", i, err)
 		}
+		seeded = append(seeded, id)
+	}
+	// Prove the seed actually landed five distinct rows before the cap
+	// assertion — otherwise the cap test degenerates to "any number ≤ 3
+	// is fine" which is tautological.
+	unique := map[int64]struct{}{}
+	for _, id := range seeded {
+		unique[id] = struct{}{}
+	}
+	if len(unique) != len(priorContents) {
+		t.Fatalf("expected %d distinct seeded observation IDs, got %d (AddObservation dedup may have collapsed them)", len(priorContents), len(unique))
 	}
 
 	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute")
 	if err != nil {
 		t.Fatalf("DetectEntityConflicts: %v", err)
 	}
-	if len(hints) > conflictHintMaxResults {
-		t.Fatalf("expected at most %d hints, got %d", conflictHintMaxResults, len(hints))
-	}
-	if len(hints) == 0 {
-		t.Fatalf("expected at least 1 hint against 5 near-duplicates, got 0")
+	if len(hints) != conflictHintMaxResults {
+		t.Fatalf("expected exactly %d hints when more than %d near-duplicates qualify, got %d", conflictHintMaxResults, conflictHintMaxResults, len(hints))
 	}
 }
 

--- a/internal/store/conflict_test.go
+++ b/internal/store/conflict_test.go
@@ -153,6 +153,75 @@ func TestDetectEntityConflicts_CapsAtMaxResults(t *testing.T) {
 	}
 }
 
+func TestHandleTool_RememberSurfacesConflictsOnNearDuplicate(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	// Seed a prior observation via HandleTool so we exercise the same
+	// path a client would take, not just the low-level primitives.
+	first, err := HandleTool(db, "remember", ToolArgs{
+		Entity:      "API",
+		Observation: "rate limit is 100 per minute",
+	})
+	if err != nil {
+		t.Fatalf("HandleTool(remember, seed) error = %v", err)
+	}
+	seed, ok := first.(RememberResult)
+	if !ok {
+		t.Fatalf("first result type = %T, want RememberResult", first)
+	}
+	if len(seed.PossibleConflicts) != 0 {
+		t.Fatalf("seed write should produce no conflicts, got %d: %+v", len(seed.PossibleConflicts), seed.PossibleConflicts)
+	}
+
+	// Follow-up write with near-duplicate content must surface the prior
+	// observation as a possible conflict on the SAME entity.
+	second, err := HandleTool(db, "remember", ToolArgs{
+		Entity:      "API",
+		Observation: "rate limit is 200 per minute",
+	})
+	if err != nil {
+		t.Fatalf("HandleTool(remember, follow-up) error = %v", err)
+	}
+	res, ok := second.(RememberResult)
+	if !ok {
+		t.Fatalf("follow-up result type = %T, want RememberResult", second)
+	}
+	if !res.Stored {
+		t.Fatalf("follow-up Stored = false, want true")
+	}
+	if len(res.PossibleConflicts) == 0 {
+		t.Fatalf("expected PossibleConflicts on near-duplicate, got 0")
+	}
+	if res.PossibleConflicts[0].ObservationID != seed.ObservationID {
+		t.Fatalf("PossibleConflicts[0].ObservationID = %d, want %d", res.PossibleConflicts[0].ObservationID, seed.ObservationID)
+	}
+	// The follow-up's own observation ID must not be in the hints
+	// (verifies the before-insert ordering choice).
+	for _, hint := range res.PossibleConflicts {
+		if hint.ObservationID == res.ObservationID {
+			t.Fatalf("hint references just-inserted observation %d — detection must run before insert", res.ObservationID)
+		}
+	}
+}
+
+func TestHandleTool_RememberOmitsConflictsFieldWhenNoneQualify(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	result, err := HandleTool(db, "remember", ToolArgs{
+		Entity:      "API",
+		Observation: "first fact ever recorded for this entity",
+	})
+	if err != nil {
+		t.Fatalf("HandleTool(remember) error = %v", err)
+	}
+	res := result.(RememberResult)
+	if len(res.PossibleConflicts) != 0 {
+		t.Fatalf("first-ever observation should not surface conflicts, got %+v", res.PossibleConflicts)
+	}
+}
+
 func TestDetectEntityConflicts_EmptyInputsShortCircuit(t *testing.T) {
 	t.Parallel()
 	db := newConflictTestDB(t)

--- a/internal/store/conflict_test.go
+++ b/internal/store/conflict_test.go
@@ -1,0 +1,199 @@
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+func newConflictTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "conflict.db")
+	db, err := openSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("openSQLite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	return db
+}
+
+func TestDetectEntityConflicts_FindsNearDuplicate(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityID, err := UpsertEntity(db, "API", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	priorID, err := AddObservation(db, entityID, "rate limit is 100 per minute", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute")
+	if err != nil {
+		t.Fatalf("DetectEntityConflicts: %v", err)
+	}
+	if len(hints) == 0 {
+		t.Fatalf("expected at least one conflict hint on near-duplicate content, got 0")
+	}
+	if hints[0].ObservationID != priorID {
+		t.Fatalf("hint[0].ObservationID = %d, want %d", hints[0].ObservationID, priorID)
+	}
+	if hints[0].Similarity < conflictHintMinScore {
+		t.Fatalf("hint[0].Similarity = %f, want >= %f", hints[0].Similarity, conflictHintMinScore)
+	}
+	if hints[0].Snippet == "" {
+		t.Fatalf("expected non-empty snippet")
+	}
+}
+
+func TestDetectEntityConflicts_IgnoresUnrelatedContent(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityID, err := UpsertEntity(db, "API", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	if _, err := AddObservation(db, entityID, "uses Postgres for storage", "user", 1.0); err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	hints, err := DetectEntityConflicts(db, entityID, "ephemeral request tracing header")
+	if err != nil {
+		t.Fatalf("DetectEntityConflicts: %v", err)
+	}
+	if len(hints) != 0 {
+		t.Fatalf("expected 0 hints on unrelated content, got %d: %+v", len(hints), hints)
+	}
+}
+
+func TestDetectEntityConflicts_RespectsEntityScope(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityA, err := UpsertEntity(db, "EntityA", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity A: %v", err)
+	}
+	if _, err := AddObservation(db, entityA, "rate limit is 100 per minute", "user", 1.0); err != nil {
+		t.Fatalf("AddObservation A: %v", err)
+	}
+
+	entityB, err := UpsertEntity(db, "EntityB", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity B: %v", err)
+	}
+
+	hints, err := DetectEntityConflicts(db, entityB, "rate limit is 200 per minute")
+	if err != nil {
+		t.Fatalf("DetectEntityConflicts: %v", err)
+	}
+	if len(hints) != 0 {
+		t.Fatalf("expected 0 hints on different entity (detection must be scoped), got %d: %+v", len(hints), hints)
+	}
+}
+
+func TestDetectEntityConflicts_IgnoresTombstonedObservations(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityID, err := UpsertEntity(db, "API", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	priorID, err := AddObservation(db, entityID, "rate limit is 100 per minute", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+	deleted, err := ForgetObservation(db, priorID)
+	if err != nil {
+		t.Fatalf("ForgetObservation: %v", err)
+	}
+	if !deleted {
+		t.Fatalf("ForgetObservation returned deleted=false")
+	}
+
+	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute")
+	if err != nil {
+		t.Fatalf("DetectEntityConflicts: %v", err)
+	}
+	if len(hints) != 0 {
+		t.Fatalf("expected 0 hints after forget (tombstone discipline), got %d: %+v", len(hints), hints)
+	}
+}
+
+func TestDetectEntityConflicts_CapsAtMaxResults(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityID, err := UpsertEntity(db, "API", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	for i := range 5 {
+		if _, err := AddObservation(db, entityID, "rate limit is 100 per minute", "user", 1.0); err != nil {
+			t.Fatalf("AddObservation[%d]: %v", i, err)
+		}
+	}
+
+	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute")
+	if err != nil {
+		t.Fatalf("DetectEntityConflicts: %v", err)
+	}
+	if len(hints) > conflictHintMaxResults {
+		t.Fatalf("expected at most %d hints, got %d", conflictHintMaxResults, len(hints))
+	}
+	if len(hints) == 0 {
+		t.Fatalf("expected at least 1 hint against 5 near-duplicates, got 0")
+	}
+}
+
+func TestDetectEntityConflicts_EmptyInputsShortCircuit(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityID, err := UpsertEntity(db, "API", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	if _, err := AddObservation(db, entityID, "rate limit is 100 per minute", "user", 1.0); err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	hints, err := DetectEntityConflicts(db, entityID, "")
+	if err != nil {
+		t.Fatalf("empty content: %v", err)
+	}
+	if len(hints) != 0 {
+		t.Fatalf("empty content should yield 0 hints, got %d", len(hints))
+	}
+
+	hints, err = DetectEntityConflicts(db, entityID, "   \t\n  ")
+	if err != nil {
+		t.Fatalf("whitespace content: %v", err)
+	}
+	if len(hints) != 0 {
+		t.Fatalf("whitespace-only content should yield 0 hints, got %d", len(hints))
+	}
+
+	hints, err = DetectEntityConflicts(db, 0, "rate limit is 200 per minute")
+	if err != nil {
+		t.Fatalf("zero entityID: %v", err)
+	}
+	if len(hints) != 0 {
+		t.Fatalf("zero entityID should yield 0 hints, got %d", len(hints))
+	}
+
+	hints, err = DetectEntityConflicts(db, -1, "rate limit is 200 per minute")
+	if err != nil {
+		t.Fatalf("negative entityID: %v", err)
+	}
+	if len(hints) != 0 {
+		t.Fatalf("negative entityID should yield 0 hints, got %d", len(hints))
+	}
+}

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -179,6 +179,14 @@ func dispatchTool(defaultDB *sql.DB, name string, args ToolArgs, outMetrics **Se
 		return RememberResult{Stored: true, EntityID: entityID, ObservationID: observationID, EventID: args.EventID, Project: stringPointer(args.Project), PossibleConflicts: conflicts}, nil
 
 	case "remember_batch":
+		// Scope decision (DECISION_LOG 2026-04-22): conflict detection is
+		// intentionally NOT extended to remember_batch. The batch surface
+		// raises its own design questions — within-batch duplicates,
+		// per-fact hints in a single response, transaction vs individual
+		// detection — that deserve their own decision rather than being
+		// smuggled in under this one. Revisit in a future Step if
+		// telemetry shows batches dominate writes and silent overwrites
+		// inside batches become material.
 		tx, err := db.Begin()
 		if err != nil {
 			return nil, fmt.Errorf("begin remember_batch: %w", err)
@@ -280,6 +288,12 @@ func dispatchTool(defaultDB *sql.DB, name string, args ToolArgs, outMetrics **Se
 		return ListEntitiesResult{Entities: entities, Total: len(entities)}, nil
 
 	case "remember_event":
+		// Scope decision (DECISION_LOG 2026-04-22): conflict detection is
+		// intentionally NOT extended to observations attached via
+		// remember_event. Same reasoning as remember_batch — per-fact
+		// hints inside an event payload is a separate design question.
+		// A single remember call against an existing entity is the
+		// targeted surface for this Step.
 		tx, err := db.Begin()
 		if err != nil {
 			return nil, fmt.Errorf("begin remember_event: %w", err)

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -43,11 +43,12 @@ type ToolArgs struct {
 }
 
 type RememberResult struct {
-	Stored        bool    `json:"stored"`
-	EntityID      int64   `json:"entity_id"`
-	ObservationID int64   `json:"observation_id"`
-	EventID       *int64  `json:"event_id,omitempty"`
-	Project       *string `json:"project,omitempty"`
+	Stored            bool           `json:"stored"`
+	EntityID          int64          `json:"entity_id"`
+	ObservationID     int64          `json:"observation_id"`
+	EventID           *int64         `json:"event_id,omitempty"`
+	Project           *string        `json:"project,omitempty"`
+	PossibleConflicts []ConflictHint `json:"possible_conflicts,omitempty"`
 }
 
 type RememberBatchFactResult struct {
@@ -164,11 +165,18 @@ func dispatchTool(defaultDB *sql.DB, name string, args ToolArgs, outMetrics **Se
 		if err != nil {
 			return nil, err
 		}
+		// Detect conflicts BEFORE insert so the detector scans an
+		// already-consistent state and self-match filtering is
+		// unnecessary. See DECISION_LOG 2026-04-22.
+		conflicts, err := DetectEntityConflicts(db, entityID, args.Observation)
+		if err != nil {
+			return nil, err
+		}
 		observationID, err := AddObservation(db, entityID, args.Observation, defaultSource(args.Source), defaultConfidence(args.Confidence), optionalEventID(args.EventID)...)
 		if err != nil {
 			return nil, err
 		}
-		return RememberResult{Stored: true, EntityID: entityID, ObservationID: observationID, EventID: args.EventID, Project: stringPointer(args.Project)}, nil
+		return RememberResult{Stored: true, EntityID: entityID, ObservationID: observationID, EventID: args.EventID, Project: stringPointer(args.Project), PossibleConflicts: conflicts}, nil
 
 	case "remember_batch":
 		tx, err := db.Begin()

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -107,6 +107,11 @@ func InitIfEnabled(path string, strict bool) *Client {
 			return nil
 		}
 	}
+	if err := applyMigrations(db); err != nil {
+		_ = db.Close()
+		initWarn(err)
+		return nil
+	}
 	insertCall, err := db.Prepare(insertCallSQL)
 	if err != nil {
 		_ = db.Close()
@@ -171,15 +176,22 @@ func (c *Client) Strict() bool {
 }
 
 // ToolCallInput captures a single tool invocation for telemetry.
+//
+// ConflictsSurfaced is the number of possible_conflicts hints returned by
+// a `remember` call. Zero for every other tool and for `remember` calls
+// that produced no hints. Used in combination with subsequent `forget`
+// calls to compute the surface-to-act ratio that calibrates the conflict
+// hint threshold (see DECISION_LOG 2026-04-22).
 type ToolCallInput struct {
-	Tool          string
-	Client        ClientInfo
-	DBScope       string // "global" or "project"
-	ProjectPath   string
-	DurationMs    float64
-	ArgsSummary   string
-	ResultSummary string
-	IsError       bool
+	Tool              string
+	Client            ClientInfo
+	DBScope           string // "global" or "project"
+	ProjectPath       string
+	DurationMs        float64
+	ArgsSummary       string
+	ResultSummary     string
+	IsError           bool
+	ConflictsSurfaced int
 }
 
 // LogToolCall inserts a tool_calls row. Returns the new row id on success or
@@ -214,6 +226,7 @@ func (c *Client) LogToolCall(in ToolCallInput) int64 {
 		nullIfEmpty(in.ArgsSummary),
 		nullIfEmpty(in.ResultSummary),
 		boolToInt(in.IsError),
+		in.ConflictsSurfaced,
 	)
 	if err != nil {
 		c.degraded = true

--- a/internal/telemetry/migrations.go
+++ b/internal/telemetry/migrations.go
@@ -46,6 +46,14 @@ func applyMigrations(db *sql.DB) error {
 // table. The PRAGMA table_info pragma is the idiomatic way to introspect
 // SQLite schema; it returns one row per column with (cid, name, type,
 // notnull, dflt_value, pk).
+//
+// INVARIANT: callers MUST pass a hardcoded table literal, never an
+// externally-derived string. SQLite does not support parameter binding
+// inside a PRAGMA expression, so the table name is interpolated via
+// fmt.Sprintf — which would be a SQL injection surface if `table` came
+// from untrusted input. The only current call site passes the literal
+// "tool_calls". Do not export this helper or accept variable table
+// names without re-evaluating the contract.
 func columnExists(db *sql.DB, table, column string) (bool, error) {
 	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
 	if err != nil {

--- a/internal/telemetry/migrations.go
+++ b/internal/telemetry/migrations.go
@@ -1,0 +1,72 @@
+package telemetry
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// toolCallsMigrations are idempotent ALTER TABLE operations applied to
+// pre-existing tool_calls tables that were created before a new column
+// was introduced. SQLite does not support ADD COLUMN IF NOT EXISTS, so
+// every migration is guarded by a PRAGMA table_info check. Each entry
+// must also appear in the CREATE TABLE in schema.go so fresh DBs are
+// born at the target shape and the ALTER path short-circuits.
+var toolCallsMigrations = []struct {
+	Column string
+	Alter  string
+}{
+	{
+		Column: "conflicts_surfaced",
+		Alter:  `ALTER TABLE tool_calls ADD COLUMN conflicts_surfaced INTEGER NOT NULL DEFAULT 0`,
+	},
+}
+
+// applyMigrations brings an existing telemetry DB up to the current schema
+// without erroring on columns that already exist. Called after the CREATE
+// TABLE IF NOT EXISTS statements in InitIfEnabled, so a freshly-created
+// table matches the target shape and every migration becomes a no-op via
+// the columnExists guard. Idempotent: safe to run repeatedly.
+func applyMigrations(db *sql.DB) error {
+	for _, mig := range toolCallsMigrations {
+		present, err := columnExists(db, "tool_calls", mig.Column)
+		if err != nil {
+			return err
+		}
+		if present {
+			continue
+		}
+		if _, err := db.Exec(mig.Alter); err != nil {
+			return fmt.Errorf("migrate tool_calls add %s: %w", mig.Column, err)
+		}
+	}
+	return nil
+}
+
+// columnExists reports whether a column is present on the given SQLite
+// table. The PRAGMA table_info pragma is the idiomatic way to introspect
+// SQLite schema; it returns one row per column with (cid, name, type,
+// notnull, dflt_value, pk).
+func columnExists(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return false, fmt.Errorf("pragma table_info(%s): %w", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			typ     string
+			notnull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk); err != nil {
+			return false, fmt.Errorf("scan pragma table_info(%s): %w", table, err)
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}

--- a/internal/telemetry/migrations_test.go
+++ b/internal/telemetry/migrations_test.go
@@ -1,0 +1,157 @@
+package telemetry
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// legacyToolCallsCreateSQL mirrors the v0.x telemetry schema, before
+// conflicts_surfaced was introduced. Used to exercise the migration path
+// so we know an existing DB upgrades cleanly when workmem is bumped past
+// this point without recreating the telemetry DB.
+const legacyToolCallsCreateSQL = `CREATE TABLE tool_calls (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts             TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now')),
+    tool           TEXT NOT NULL,
+    client_name    TEXT,
+    client_version TEXT,
+    client_source  TEXT,
+    db_scope       TEXT NOT NULL DEFAULT 'global',
+    project_path   TEXT,
+    duration_ms    REAL,
+    args_summary   TEXT,
+    result_summary TEXT,
+    is_error       INTEGER NOT NULL DEFAULT 0
+)`
+
+func openRawTelemetryDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("file:%s?_pragma=foreign_keys(1)", filepath.Clean(path))
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open raw telemetry db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestApplyMigrationsOnFreshDBIsNoop(t *testing.T) {
+	t.Parallel()
+	// InitIfEnabled runs applyMigrations as part of setup; the column must
+	// already exist after init so the subsequent explicit call short-circuits
+	// via columnExists and stays a no-op under repeated invocation.
+	path := filepath.Join(t.TempDir(), "fresh.db")
+	c := InitIfEnabled(path, false)
+	if c == nil {
+		t.Fatalf("InitIfEnabled returned nil")
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	rdb := openRawTelemetryDB(t, path)
+	present, err := columnExists(rdb, "tool_calls", "conflicts_surfaced")
+	if err != nil {
+		t.Fatalf("columnExists: %v", err)
+	}
+	if !present {
+		t.Fatalf("conflicts_surfaced column missing after fresh InitIfEnabled")
+	}
+	// Idempotent second pass must not error.
+	if err := applyMigrations(rdb); err != nil {
+		t.Fatalf("applyMigrations second pass: %v", err)
+	}
+	if err := applyMigrations(rdb); err != nil {
+		t.Fatalf("applyMigrations third pass: %v", err)
+	}
+}
+
+func TestApplyMigrationsUpgradesLegacyDB(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	db := openRawTelemetryDB(t, path)
+
+	// Seed a legacy schema that pre-dates the conflicts_surfaced column.
+	if _, err := db.Exec(legacyToolCallsCreateSQL); err != nil {
+		t.Fatalf("seed legacy table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO tool_calls (tool) VALUES ('legacy-row')`); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	before, err := columnExists(db, "tool_calls", "conflicts_surfaced")
+	if err != nil {
+		t.Fatalf("columnExists before: %v", err)
+	}
+	if before {
+		t.Fatalf("legacy table already had conflicts_surfaced — test fixture is wrong")
+	}
+
+	if err := applyMigrations(db); err != nil {
+		t.Fatalf("applyMigrations on legacy: %v", err)
+	}
+
+	after, err := columnExists(db, "tool_calls", "conflicts_surfaced")
+	if err != nil {
+		t.Fatalf("columnExists after: %v", err)
+	}
+	if !after {
+		t.Fatalf("conflicts_surfaced column missing after migration")
+	}
+
+	// Existing rows get the NOT NULL DEFAULT 0 from the ADD COLUMN.
+	var legacyValue int
+	if err := db.QueryRow(`SELECT conflicts_surfaced FROM tool_calls WHERE tool = 'legacy-row'`).Scan(&legacyValue); err != nil {
+		t.Fatalf("read legacy row conflicts_surfaced: %v", err)
+	}
+	if legacyValue != 0 {
+		t.Fatalf("legacy row conflicts_surfaced = %d, want 0 (ADD COLUMN default)", legacyValue)
+	}
+
+	// Second application is a pure no-op.
+	if err := applyMigrations(db); err != nil {
+		t.Fatalf("applyMigrations second pass: %v", err)
+	}
+}
+
+func TestLogToolCallPersistsConflictsSurfaced(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "conflicts-surfaced.db")
+	c := InitIfEnabled(path, false)
+	if c == nil {
+		t.Fatalf("InitIfEnabled returned nil")
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	cases := []struct {
+		name  string
+		tool  string
+		count int
+	}{
+		{"remember-zero", "remember", 0},
+		{"remember-one", "remember", 1},
+		{"remember-three", "remember", 3},
+		{"forget-zero-unrelated", "forget", 0},
+	}
+	ids := make(map[string]int64, len(cases))
+	for _, tc := range cases {
+		id := c.LogToolCall(ToolCallInput{Tool: tc.tool, ConflictsSurfaced: tc.count})
+		if id == 0 {
+			t.Fatalf("LogToolCall(%q) returned 0", tc.name)
+		}
+		ids[tc.name] = id
+	}
+
+	rdb := openRawTelemetryDB(t, path)
+	for _, tc := range cases {
+		var stored int
+		if err := rdb.QueryRow(`SELECT conflicts_surfaced FROM tool_calls WHERE id = ?`, ids[tc.name]).Scan(&stored); err != nil {
+			t.Fatalf("readback %q: %v", tc.name, err)
+		}
+		if stored != tc.count {
+			t.Fatalf("%q conflicts_surfaced = %d, want %d", tc.name, stored, tc.count)
+		}
+	}
+}

--- a/internal/telemetry/schema.go
+++ b/internal/telemetry/schema.go
@@ -4,20 +4,26 @@ package telemetry
 // follows the same single-statement-per-Exec pattern (see
 // internal/store/sqlite.go InitSchema) — more portable across SQLite
 // drivers than chaining multiple statements into one db.Exec call.
+//
+// New columns added to tool_calls after initial release are declared in the
+// CREATE TABLE below AND paired with an entry in toolCallsMigrations so
+// existing DBs can catch up via ALTER TABLE (see migrations.go). SQLite
+// does not support ADD COLUMN IF NOT EXISTS, so this pair is the idiom.
 var schemaStatements = []string{
 	`CREATE TABLE IF NOT EXISTS tool_calls (
-    id             INTEGER PRIMARY KEY AUTOINCREMENT,
-    ts             TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now')),
-    tool           TEXT NOT NULL,
-    client_name    TEXT,
-    client_version TEXT,
-    client_source  TEXT,
-    db_scope       TEXT NOT NULL DEFAULT 'global',
-    project_path   TEXT,
-    duration_ms    REAL,
-    args_summary   TEXT,
-    result_summary TEXT,
-    is_error       INTEGER NOT NULL DEFAULT 0
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts                 TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now')),
+    tool               TEXT NOT NULL,
+    client_name        TEXT,
+    client_version     TEXT,
+    client_source      TEXT,
+    db_scope           TEXT NOT NULL DEFAULT 'global',
+    project_path       TEXT,
+    duration_ms        REAL,
+    args_summary       TEXT,
+    result_summary     TEXT,
+    is_error           INTEGER NOT NULL DEFAULT 0,
+    conflicts_surfaced INTEGER NOT NULL DEFAULT 0
 )`,
 	`CREATE TABLE IF NOT EXISTS search_metrics (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -39,8 +45,8 @@ var schemaStatements = []string{
 
 const (
 	insertCallSQL = `INSERT INTO tool_calls
-	(tool, client_name, client_version, client_source, db_scope, project_path, duration_ms, args_summary, result_summary, is_error)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	(tool, client_name, client_version, client_source, db_scope, project_path, duration_ms, args_summary, result_summary, is_error, conflicts_surfaced)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	insertSearchSQL = `INSERT INTO search_metrics
 	(tool_call_id, query, channels, candidates_total, results_returned, limit_requested, score_min, score_max, score_median, compact)


### PR DESCRIPTION
Implements the 2026-04-22 decision (see `DECISION_LOG.md`): `remember` surfaces same-entity near-duplicate observations on the response so the agent can call `forget(observation_id)` and perform supersession-as-forget. Motivated by 8 days of production telemetry showing a 14/14 silent-overwrite rate — the agent was never performing supersession on its own despite prompt guidance.

## What ships

- **Scoped detection** (`internal/store/conflict.go`) reuses the composite ranker (`fts_phrase`, `fts`, `content_like`) scoped to `entity_id = E AND deleted_at IS NULL`. Read-only, no access-count touches, no state mutation. Three tunable constants (threshold `0.6`, max hints `3`, snippet `120`) documented as provisional and calibrated via telemetry.
- **Response extension** (`RememberResult.PossibleConflicts`): additive field with `omitempty` so clients unaware of it see an unchanged response. Contract in `API_CONTRACT.md` under "Additive response extensions (post-parity)".
- **Telemetry** (`tool_calls.conflicts_surfaced INTEGER`): idempotent `ALTER TABLE ADD COLUMN` migration for existing DBs via `PRAGMA table_info` guard; wired through `LogToolCall`. Closes the calibration loop — the threshold is tuned on evidence, not at design time.
- **One-line LLM guidance** in `README.md`: *"If `remember` returns `possible_conflicts`, review those observations and call `forget(obs_id)` on any your new fact supersedes."*

## Step Gate

`TestStepGateConflictHintEndToEndLoop` in `internal/mcpserver/telemetry_integration_test.go` is the Step 4.1 Gate fixture. It exercises the full loop over in-memory MCP transport:

1. seed `remember` → no hints
2. near-duplicate `remember` → hint references seed `observation_id`
3. `forget(observation_id=seed)` → soft-delete
4. `recall` → only the surviving observation (FTS + ranking respect the tombstone)
5. telemetry rows reflect `conflicts_surfaced = {0, >=1, 0, 0}`

Full suite green under `-race`, `go vet` clean, pure-Go invariant preserved (`CGO_ENABLED=0`), no new MCP tool (12-tool ceiling intact), `forget` semantics unchanged.

## What does not ship (deliberately)

- **No reranker** — the design chat concluded "seam not implementation"; candidate for Step 4.2.
- **No semantic embeddings** — would break the pure-Go single-binary invariant; revisit if the lexical layer proves insufficient.
- **No auto-supersede** — rejected in DECISION_LOG. Similarity ≠ contradiction, and only `forget` mutates canonical state.

## Review plan

Tripartite review (security + correctness + architecture) with Diana ontology, repo access required. The architecture reviewer additionally runs an Integration Pulse on the MCP dispatch path: *"is the new `possible_conflicts` path reachable from the stdio entrypoint for every MCP client that calls `remember`, and does the telemetry addition preserve the opt-in invariant?"*. Findings will land in `review/` and then be persisted to the Supabase findings store.

## Test plan

- [x] `go test ./...` green
- [x] `go test -race ./...` green
- [x] `go vet ./...` clean
- [x] Step Gate fixture passes
- [ ] Diana security review
- [ ] Diana correctness review
- [ ] Diana architecture review + Integration Pulse
- [ ] Blockers addressed, findings persisted to Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)