### PR TITLE
fix: scope-aware halfLifeWeeks for DetectEntityConflicts (PR #11 follow-up)

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -131,7 +131,7 @@ Evolve workmem beyond Node parity. Each step is motivated by telemetry
 evidence, not speculation, and every step ships a measurement path so
 its own effectiveness becomes observable.
 
-### Step 4.1: Conflict hints in `remember` response [🔧]
+### Step 4.1: Conflict hints in `remember` response [✅]
 
 Surface same-entity near-duplicate observations when the agent calls
 `remember`, so supersession-as-forget becomes observable from the

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -32,6 +32,7 @@ Fix (calibration protocol):
   3. Distribution check: inspect the raw similarity scores of surfaced hints that were NOT acted on. If they cluster near the threshold, the threshold is too low. If they span the full range, the prompt line or agent discipline is the bottleneck, not the threshold.
   4. Adjust in 0.05 increments, one change per cycle. Record the change in DECISION_LOG as an append-only entry with the evidence summary.
   5. After adjustment, reset the sample window and re-measure.
+  6. Split telemetry by `tool_calls.db_scope` before computing the ratio. Global memory uses `MEMORY_HALF_LIFE_WEEKS` (12 by default) and project memory uses `PROJECT_MEMORY_HALF_LIFE_WEEKS` (52 by default), so observations of the same age decay differently across scopes and produce systematically different composite scores. Mixing both scopes into one ratio averages two distributions and pins a threshold that fits neither. The schema already exposes `db_scope`; the obligation is on the analysis path. Same goes for any future per-instance half-life override.
 Done when: either the threshold has been confirmed twice in a row at the same value with the ratio inside [0.5, 0.9], or telemetry has shown a clear reason to redesign the hint (e.g., lexical detection consistently misses semantic conflicts and a pure-Go embedding path becomes available).
 
 - The Go port now replays the shared product fixtures locally, but still lacks an automated Node-vs-Go dual-runtime comparison in CI.

--- a/internal/store/conflict.go
+++ b/internal/store/conflict.go
@@ -39,9 +39,17 @@ const conflictHintMaxResults = 3
 // event-based channels are skipped because they are constant or irrelevant
 // inside a single entity.
 //
+// halfLifeWeeks is the decay rate the caller computed from request scope
+// (global ⇒ memoryHalfLifeWeeks(), project ⇒ projectMemoryHalfLifeWeeks()).
+// Mirrors the explicit-parameter pattern of SearchMemory so the detector
+// scores observations against the same decay surface the agent's recall
+// would use, not a hardcoded global default. If the wrong rate is supplied
+// here, project-scoped supersession hints get suppressed because the older
+// observations decay below the conflict threshold under global decay.
+//
 // Callers should invoke this BEFORE inserting the new observation so that
 // self-match filtering is unnecessary.
-func DetectEntityConflicts(db *sql.DB, entityID int64, content string) ([]ConflictHint, error) {
+func DetectEntityConflicts(db *sql.DB, entityID int64, content string, halfLifeWeeks float64) ([]ConflictHint, error) {
 	trimmed := strings.TrimSpace(content)
 	if entityID <= 0 || trimmed == "" {
 		return nil, nil
@@ -65,7 +73,7 @@ func DetectEntityConflicts(db *sql.DB, entityID int64, content string) ([]Confli
 
 	// Preserve every candidate through scoring so we can threshold-filter
 	// next. Passing len(hydrated) as the limit means no truncation here.
-	ranked := ScoreCandidates(hydrated, candidates, memoryHalfLifeWeeks(), len(hydrated))
+	ranked := ScoreCandidates(hydrated, candidates, halfLifeWeeks, len(hydrated))
 
 	hints := make([]ConflictHint, 0, conflictHintMaxResults)
 	for _, obs := range ranked {

--- a/internal/store/conflict_test.go
+++ b/internal/store/conflict_test.go
@@ -33,7 +33,7 @@ func TestDetectEntityConflicts_FindsNearDuplicate(t *testing.T) {
 		t.Fatalf("AddObservation: %v", err)
 	}
 
-	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute")
+	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute", memoryHalfLifeWeeks())
 	if err != nil {
 		t.Fatalf("DetectEntityConflicts: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestDetectEntityConflicts_IgnoresUnrelatedContent(t *testing.T) {
 		t.Fatalf("AddObservation: %v", err)
 	}
 
-	hints, err := DetectEntityConflicts(db, entityID, "ephemeral request tracing header")
+	hints, err := DetectEntityConflicts(db, entityID, "ephemeral request tracing header", memoryHalfLifeWeeks())
 	if err != nil {
 		t.Fatalf("DetectEntityConflicts: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestDetectEntityConflicts_RespectsEntityScope(t *testing.T) {
 		t.Fatalf("UpsertEntity B: %v", err)
 	}
 
-	hints, err := DetectEntityConflicts(db, entityB, "rate limit is 200 per minute")
+	hints, err := DetectEntityConflicts(db, entityB, "rate limit is 200 per minute", memoryHalfLifeWeeks())
 	if err != nil {
 		t.Fatalf("DetectEntityConflicts: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestDetectEntityConflicts_IgnoresTombstonedObservations(t *testing.T) {
 		t.Fatalf("ForgetObservation returned deleted=false")
 	}
 
-	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute")
+	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute", memoryHalfLifeWeeks())
 	if err != nil {
 		t.Fatalf("DetectEntityConflicts: %v", err)
 	}
@@ -166,7 +166,7 @@ func TestDetectEntityConflicts_CapsAtMaxResults(t *testing.T) {
 		t.Fatalf("expected %d distinct seeded observation IDs, got %d (AddObservation dedup may have collapsed them)", len(priorContents), len(unique))
 	}
 
-	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute")
+	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute", memoryHalfLifeWeeks())
 	if err != nil {
 		t.Fatalf("DetectEntityConflicts: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestDetectEntityConflicts_EmptyInputsShortCircuit(t *testing.T) {
 		t.Fatalf("AddObservation: %v", err)
 	}
 
-	hints, err := DetectEntityConflicts(db, entityID, "")
+	hints, err := DetectEntityConflicts(db, entityID, "", memoryHalfLifeWeeks())
 	if err != nil {
 		t.Fatalf("empty content: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestDetectEntityConflicts_EmptyInputsShortCircuit(t *testing.T) {
 		t.Fatalf("empty content should yield 0 hints, got %d", len(hints))
 	}
 
-	hints, err = DetectEntityConflicts(db, entityID, "   \t\n  ")
+	hints, err = DetectEntityConflicts(db, entityID, "   \t\n  ", memoryHalfLifeWeeks())
 	if err != nil {
 		t.Fatalf("whitespace content: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestDetectEntityConflicts_EmptyInputsShortCircuit(t *testing.T) {
 		t.Fatalf("whitespace-only content should yield 0 hints, got %d", len(hints))
 	}
 
-	hints, err = DetectEntityConflicts(db, 0, "rate limit is 200 per minute")
+	hints, err = DetectEntityConflicts(db, 0, "rate limit is 200 per minute", memoryHalfLifeWeeks())
 	if err != nil {
 		t.Fatalf("zero entityID: %v", err)
 	}
@@ -280,7 +280,7 @@ func TestDetectEntityConflicts_EmptyInputsShortCircuit(t *testing.T) {
 		t.Fatalf("zero entityID should yield 0 hints, got %d", len(hints))
 	}
 
-	hints, err = DetectEntityConflicts(db, -1, "rate limit is 200 per minute")
+	hints, err = DetectEntityConflicts(db, -1, "rate limit is 200 per minute", memoryHalfLifeWeeks())
 	if err != nil {
 		t.Fatalf("negative entityID: %v", err)
 	}

--- a/internal/store/conflict_test.go
+++ b/internal/store/conflict_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func newConflictTestDB(t *testing.T) *sql.DB {
@@ -241,6 +242,72 @@ func TestHandleTool_RememberOmitsConflictsFieldWhenNoneQualify(t *testing.T) {
 	res := result.(RememberResult)
 	if len(res.PossibleConflicts) != 0 {
 		t.Fatalf("first-ever observation should not surface conflicts, got %+v", res.PossibleConflicts)
+	}
+}
+
+// TestDetectEntityConflicts_HalfLifeParameterAffectsThreshold is the
+// regression fence for the bug Kimi's general-focus review caught after
+// PR #11 merged: DetectEntityConflicts had been hardcoding
+// memoryHalfLifeWeeks(), so project-scoped writes scored older
+// observations under the wrong (more aggressive) decay rate and silently
+// suppressed legitimate conflict hints.
+//
+// The test pins the failure mode in a deterministic regime: a
+// content_like-only match on an 8-week-old observation falls in the
+// composite-score band where decay alone determines surfacing. Under
+// global half-life (12w) the candidate decays below the 0.6 threshold;
+// under project half-life (52w) it stays above. The test asserts both
+// halves of that delta against the SAME observation and content, so any
+// future regression that drops the parameter back to a hardcoded default
+// flips one of the two assertions.
+func TestDetectEntityConflicts_HalfLifeParameterAffectsThreshold(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityID, err := UpsertEntity(db, "scaler-config", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	obsID, err := AddObservation(db, entityID, "scaler max_concurrent value 32", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+
+	// Backdate the observation to 8 weeks. Format mirrors the SQLite
+	// `datetime('now')` shape produced by the schema default so the
+	// downstream parseSQLiteTime helper recognizes it identically.
+	eightWeeksAgo := time.Now().UTC().AddDate(0, 0, -56).Format("2006-01-02 15:04:05.000")
+	if _, err := db.Exec(`UPDATE observations SET created_at = ? WHERE id = ?`, eightWeeksAgo, obsID); err != nil {
+		t.Fatalf("backdate observation: %v", err)
+	}
+
+	// "scal" is a strict substring of "scaler" but not a complete FTS
+	// token, so only the content_like channel (weight 0.5) fires. That
+	// pins composite = 0.5*0.7 + decayed*0.3 = 0.35 + 0.3*decayed,
+	// crossing the 0.6 threshold exactly when decayed crosses 0.833. At
+	// 8 weeks, 12w half-life decays to 0.629 (below 0.833 ⇒ suppressed);
+	// 52w half-life decays to 0.899 (above ⇒ surfaces).
+	const followContent = "scal"
+
+	globalHints, err := DetectEntityConflicts(db, entityID, followContent, memoryHalfLifeWeeks())
+	if err != nil {
+		t.Fatalf("global-halflife detect: %v", err)
+	}
+	if len(globalHints) != 0 {
+		t.Fatalf("global half-life (%vw) should suppress an 8-week-old content_like-only candidate; got %+v",
+			memoryHalfLifeWeeks(), globalHints)
+	}
+
+	projectHints, err := DetectEntityConflicts(db, entityID, followContent, projectMemoryHalfLifeWeeks())
+	if err != nil {
+		t.Fatalf("project-halflife detect: %v", err)
+	}
+	if len(projectHints) == 0 {
+		t.Fatalf("project half-life (%vw) should surface an 8-week-old content_like-only candidate; got 0 hints",
+			projectMemoryHalfLifeWeeks())
+	}
+	if projectHints[0].ObservationID != obsID {
+		t.Fatalf("project hint observation_id = %d, want seed %d", projectHints[0].ObservationID, obsID)
 	}
 }
 

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -167,8 +167,11 @@ func dispatchTool(defaultDB *sql.DB, name string, args ToolArgs, outMetrics **Se
 		}
 		// Detect conflicts BEFORE insert so the detector scans an
 		// already-consistent state and self-match filtering is
-		// unnecessary. See DECISION_LOG 2026-04-22.
-		conflicts, err := DetectEntityConflicts(db, entityID, args.Observation)
+		// unnecessary. See DECISION_LOG 2026-04-22. Pass the
+		// scope-aware halfLife computed above so project memory uses
+		// its own (longer) decay rate when scoring potential conflicts
+		// — see Kimi general-review finding (PR #11 follow-up).
+		conflicts, err := DetectEntityConflicts(db, entityID, args.Observation, halfLife)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Context

Follow-up to PR #11 (Phase 4 Step 4.1 — conflict hints in `remember`). The tripartite Diana review on PR #11 returned 0 blockers and 6 risks, all addressed before merge. A subsequent **Kimi general-focus review** (manyminds `diana-kimi`, Kimi k2.6 with Diana ontology, 256k context) caught a real interaction-effect bug that the focused tripartite axes had missed.

## The bug

`DetectEntityConflicts` was hardcoding `memoryHalfLifeWeeks()` (the global 12-week default), ignoring the per-scope `halfLife` already correctly computed by `dispatchTool` for project-routed calls. Project memory uses a 52-week half-life (`PROJECT_MEMORY_HALF_LIFE_WEEKS`) by design — older facts persist longer in relevance — so detection was scoring project-scoped observations under the wrong (more aggressive) decay rate, silently suppressing legitimate conflict hints.

Magnitude (verified math, see commit body): an 8-week-old observation with a `content_like`-only match (relevance 0.5) scores 0.539 with the buggy global half-life (below the 0.6 threshold ⇒ suppressed) versus 0.620 with the correct project half-life (above ⇒ surfaces). The projects with the longest-lived knowledge — exactly the case project memory was designed for — were the ones losing supersession hints.

## Why tripartite missed it

Quoting Kimi: *"Security/correctness/architecture axes don't naturally trace the `halfLife` parameter from dispatch through to the new detection path — it's an interaction effect between project-routing configuration and the new ranker call site."*

This is the empirical justification for keeping a Kimi general pass in the review rotation — the **`diana-kimi`** agent is now noted in cross-session memory as worth keeping in mind for review rounds.

## What this PR ships

**`5671a9a fix(store): pass scope-aware halfLifeWeeks to DetectEntityConflicts`**
- Adds `halfLifeWeeks float64` parameter to `DetectEntityConflicts`, mirroring `SearchMemory`'s signature.
- Updates the `dispatchTool` `remember` case to pass the existing `halfLife` variable.
- Doc block on the function explicitly calls out the suppression failure mode.
- Adjusts existing `conflict_test.go` calls to pass `memoryHalfLifeWeeks()` explicitly (no semantic change).

**`281ebb5 test(store): regression fence for half-life-affects-threshold property`**
- `TestDetectEntityConflicts_HalfLifeParameterAffectsThreshold` pins the failure mode in a deterministic regime: same observation, same query, same entity — only the `halfLifeWeeks` parameter differs. Under global half-life the candidate is suppressed; under project half-life it surfaces. Any future regression that drops the parameter back to a hardcoded default flips one assertion.

**`b416544 docs: scope-split note for calibration + close Step 4.1`**
- `OPERATIONS.md` calibration P1 entry gains step 6: telemetry analysis MUST split surface-to-act ratios by `tool_calls.db_scope` before averaging. Schema already exposes the column.
- `IMPLEMENTATION.md` Step 4.1 flips from `[🔧]` to `[✅]`. The original Step Gate (end-to-end conflict-hint loop) was green by accident of being tested only on global scope; with this fix it is green by design across both scopes.

## What does not ship

- No change to `ConflictHint` / `DetectEntityConflicts` exported visibility (Kimi flagged as code-hygiene minor — blast radius zero under `internal/`, churn for no benefit).
- No new MCP integration test for project-routing wiring — the call-site change is a single token (`, halfLife`) and a regression at that site would be a compile error or trivially flipped by the new unit fence.

## Test plan

- [x] `go test ./...` green
- [x] `go test -race ./...` green
- [x] `go vet ./...` clean
- [x] Regression fence demonstrates the bug-vs-fix delta
- [ ] CI green on the 3 OS + 5 cross-build matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)