### PR TITLE
fix(store): enforce event expiry and private storage

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -30,7 +30,8 @@ The Go implementation should preserve the MCP tool surface unless there is a del
 - `recall` returns ranked grouped results with confidence and composite score semantics preserved as closely as practical.
 - `forget` soft-deletes observations or entities and must remove deleted observations from FTS recall.
 - `project`-scoped calls route to an isolated DB under the target project.
-- provenance tools bypass ranking and return direct facts by identifier.
+- provenance tools bypass ranking and return direct facts by identifier, but they must not bypass lifecycle visibility guards such as tombstones or event expiry.
+- `remember_event.expires_at`, when provided, must be a valid timestamp. Expired events and observations attached to expired events are hidden from normal read surfaces: `recall`, `recall_entity`, `recall_events`, `recall_event`, `get_observations`, and `get_event_observations`.
 
 ## Compatibility policy
 

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -1,5 +1,59 @@
 # DECISION LOG
 
+## 2026-04-26: Event expiry is a lifecycle guard, not just an event-list filter
+
+### Context
+
+`remember_event` exposed `expires_at` as "Event auto-hides after this
+time", but the implementation only hid expired events from
+`recall_events`. Direct event lookup, direct observation hydration, entity
+recall, and general recall could still surface observations attached to
+expired events. That made expiry a partial UI filter instead of a real
+lifecycle boundary.
+
+The same hardening pass found two adjacent pre-v1 issues: local memory DB
+directories were created with `0755`, and the SQLite canary considered any
+orphan-observation insert error as proof that foreign keys were enforced.
+
+### Decision
+
+Treat `expires_at` as a normal read-surface guard. Expired events and
+observations attached to expired events are hidden from `recall`,
+`recall_entity`, `recall_events`, `recall_event`, `get_observations`, and
+`get_event_observations`. Observations with no event remain visible.
+
+`expires_at` is validated on write and normalized to a UTC SQLite timestamp
+so SQLite `datetime()` comparisons are deterministic. Invalid expiry values
+are rejected instead of being stored as opaque strings.
+
+New memory directories are created as `0700`, and SQLite DB files are
+best-effort hardened to `0600` on POSIX filesystems. The canary now only
+accepts a real SQLite foreign-key constraint error as proof that orphan
+observation inserts are rejected.
+
+### Rationale
+
+- Expiry is a product contract. Direct ID lookup is provenance access, not
+  an admin bypass.
+- Hiding attached observations matches the model that an event can make a
+  fact temporary. Permanent facts should be stored outside an expiring
+  event.
+- A local memory server can contain private or therapeutic material;
+  permissive default directory modes are the wrong baseline for new DBs.
+- A canary that can false-pass on arbitrary insert errors is worse than no
+  canary because it produces false confidence.
+
+### Alternatives considered
+
+- **Add `include_expired`.** Rejected for v1. It weakens the default mental
+  model and adds a new footgun before there is a demonstrated recovery or
+  audit workflow.
+- **Only hide events, not attached observations.** Rejected. It leaves
+  temporary event facts visible through general recall and defeats the
+  reason to attach them to an expiring event.
+- **Performance rewrites during the same pass.** Rejected. Retrieval
+  optimization needs benchmark evidence; this pass is contract hardening.
+
 ## 2026-04-22: Surface near-duplicate observations in `remember` response; supersession stays agent-driven
 
 ### Context

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -26,10 +26,10 @@ observations attached to expired events are hidden from `recall`,
 so SQLite `datetime()` comparisons are deterministic. Invalid expiry values
 are rejected instead of being stored as opaque strings.
 
-New memory directories are created as `0700`, and SQLite DB files are
-best-effort hardened to `0600` on POSIX filesystems. The canary now only
-accepts a real SQLite foreign-key constraint error as proof that orphan
-observation inserts are rejected.
+New memory directories are created as `0700`, and SQLite DB files plus
+SQLite sidecars are best-effort hardened to `0600` on POSIX filesystems.
+The canary now only accepts a real SQLite foreign-key constraint error as
+proof that orphan observation inserts are rejected.
 
 ### Rationale
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -182,3 +182,26 @@ Integration Pulse. Review focus points: the scoped detection must not
 leak into global ranking; the telemetry additions must preserve the
 opt-in invariant (`MEMORY_TELEMETRY_PATH` unset ⇒ zero overhead); the
 new response field must not break existing clients that ignore it.
+
+### Step 4.2: Semantic hardening for expiry and local privacy [✅]
+
+Close pre-v1 contract leaks found during external review: event expiry
+must hide temporary context consistently, local memory files should be
+private by default, and the SQLite canary must fail for the right reason.
+**Gate:** `go test ./...` proves expired event observations are hidden
+from all normal read surfaces, new DB paths use private POSIX modes, and
+the orphan-observation canary only accepts a foreign-key constraint
+failure.
+
+- [x] Treat `expires_at` as a lifecycle visibility guard across recall,
+  entity recall, event recall, and direct observation hydration
+- [x] Validate and normalize `expires_at` on event creation
+- [x] Create new memory directories with `0700` and best-effort chmod DB
+  files to `0600`
+- [x] Make `RejectsOrphanObservationInsert` validate the SQLite
+  foreign-key error specifically
+- [x] Update `API_CONTRACT.md`, `OPERATIONS.md`, and `DECISION_LOG.md`
+  with the tightened contract
+
+**On Step Gate (all items [x]):** trigger focused correctness/security
+review before release tagging.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -9,11 +9,13 @@
 - The SQLite viability baseline is the `modernc.org/sqlite` driver until evidence proves it cannot carry parity.
 - Project-scoped storage must never leak into global storage.
 - Live-data queries must never bypass tombstone guards.
+- Live-data queries must never bypass event-expiry guards: expired events and observations attached to expired events are hidden from normal read surfaces, including direct provenance hydration by ID.
 - FTS cleanup must never use raw `DELETE` against a contentless FTS table.
 - `remember_event` must be atomic: the event row and all attached observations commit together or not at all. Proof: `TestRememberEventAtomicityOnMidLoopFailure` in `internal/store/parity_test.go`.
 - Telemetry is opt-in (`MEMORY_TELEMETRY_PATH`) and never affects the tool call success path. Init failure logs a single warning to stderr and disables telemetry for the session; the main memory DB is unaffected.
 - Telemetry data lives in its own SQLite file, physically separate from the memory database. No foreign keys, no joins, no shared lifecycle.
 - When `MEMORY_TELEMETRY_PRIVACY=strict`, entity names, queries, and event labels must be sha256-hashed before reaching disk. Observation/content values are always reduced to `<N chars>` regardless of mode.
+- New memory directories must be private by default (`0700`) and SQLite DB files are best-effort hardened to `0600` on POSIX filesystems.
 
 ## Active Debt
 
@@ -63,7 +65,11 @@ Done when: FTS-specific parity tests pass across the release matrix.
 
 ### P2
 
-- None active.
+- Schema migrations are still inline `ALTER TABLE` statements guarded by duplicate-schema string matching.
+Trigger: Adding more migrations before replacing the guard with explicit migration tracking.
+Blast radius: A real migration error could be mistaken for an idempotent duplicate-schema condition, or a legacy DB path could drift from fresh schema behavior.
+Fix: add `schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)` before v1; keep fresh `CREATE TABLE IF NOT EXISTS` bootstrap and prove legacy upgrades with regression tests.
+Done when: each migration has a version, runs once, and legacy-schema tests no longer depend on string-matching duplicate column errors.
 
 ## Pre-Launch TODO
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -15,7 +15,7 @@
 - Telemetry is opt-in (`MEMORY_TELEMETRY_PATH`) and never affects the tool call success path. Init failure logs a single warning to stderr and disables telemetry for the session; the main memory DB is unaffected.
 - Telemetry data lives in its own SQLite file, physically separate from the memory database. No foreign keys, no joins, no shared lifecycle.
 - When `MEMORY_TELEMETRY_PRIVACY=strict`, entity names, queries, and event labels must be sha256-hashed before reaching disk. Observation/content values are always reduced to `<N chars>` regardless of mode.
-- New memory directories must be private by default (`0700`) and SQLite DB files are best-effort hardened to `0600` on POSIX filesystems.
+- New memory directories must be private by default (`0700`) and SQLite DB files plus SQLite sidecars (`-wal`, `-shm`, `-journal`) are best-effort hardened to `0600` on POSIX filesystems.
 
 ## Active Debt
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -53,8 +53,8 @@ func New(config Config) (*Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
-		return nil, fmt.Errorf("create database directory: %w", err)
+	if err := ensureDatabaseDir(filepath.Dir(dbPath)); err != nil {
+		return nil, err
 	}
 
 	db, err := store.InitDB(dbPath)
@@ -71,6 +71,23 @@ func New(config Config) (*Runtime, error) {
 	runtime.telemetry.Store(config.Telemetry)
 	runtime.registerTools()
 	return runtime, nil
+}
+
+func ensureDatabaseDir(dbDir string) error {
+	created := false
+	if _, err := os.Stat(dbDir); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("stat database directory: %w", err)
+		}
+		created = true
+	}
+	if err := os.MkdirAll(dbDir, 0o700); err != nil {
+		return fmt.Errorf("create database directory: %w", err)
+	}
+	if created {
+		_ = os.Chmod(dbDir, 0o700)
+	}
+	return nil
 }
 
 func (r *Runtime) Run(ctx context.Context, transport mcp.Transport) error {

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -3,8 +3,10 @@ package mcpserver
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -130,6 +132,71 @@ func TestServerListsToolsAndCallsBackend(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("runtime.Run() did not exit after client shutdown")
+	}
+}
+
+func TestNewCreatesPrivateDatabaseDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not portable on Windows")
+	}
+
+	dbDir := filepath.Join(t.TempDir(), "state")
+	rt, err := New(Config{DBPath: filepath.Join(dbDir, "memory.db")})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer rt.Close()
+
+	info, err := os.Stat(dbDir)
+	if err != nil {
+		t.Fatalf("stat db dir error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("db dir mode = %o, want 700", got)
+	}
+
+	dbInfo, err := os.Stat(filepath.Join(dbDir, "memory.db"))
+	if err != nil {
+		t.Fatalf("stat db file error = %v", err)
+	}
+	if got := dbInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("db file mode = %o, want 600", got)
+	}
+}
+
+func TestNewDoesNotTightenExistingDatabaseDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not portable on Windows")
+	}
+
+	dbDir := filepath.Join(t.TempDir(), "existing")
+	if err := os.Mkdir(dbDir, 0o755); err != nil {
+		t.Fatalf("mkdir existing db dir error = %v", err)
+	}
+	if err := os.Chmod(dbDir, 0o755); err != nil {
+		t.Fatalf("chmod existing db dir error = %v", err)
+	}
+
+	rt, err := New(Config{DBPath: filepath.Join(dbDir, "memory.db")})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer rt.Close()
+
+	info, err := os.Stat(dbDir)
+	if err != nil {
+		t.Fatalf("stat db dir error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("existing db dir mode = %o, want preserved 755", got)
+	}
+
+	dbInfo, err := os.Stat(filepath.Join(dbDir, "memory.db"))
+	if err != nil {
+		t.Fatalf("stat db file error = %v", err)
+	}
+	if got := dbInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("db file mode = %o, want 600", got)
 	}
 }
 

--- a/internal/store/conflict.go
+++ b/internal/store/conflict.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 )
 
@@ -122,13 +123,13 @@ func collectEntityScopedCandidates(db *sql.DB, entityID int64, content string) (
 	// fts_phrase — full phrase, only meaningful with multiple terms.
 	if len(cleanTerms) > 1 {
 		phraseQuery := `"` + strings.Join(cleanTerms, " ") + `"`
-		rows, err := db.Query(`
+		rows, err := db.Query(fmt.Sprintf(`
 			SELECT memory_fts.rowid, memory_fts.rank
 			FROM memory_fts
 			JOIN observations o ON o.id = memory_fts.rowid
-			WHERE memory_fts MATCH ? AND o.entity_id = ? AND o.deleted_at IS NULL
+			WHERE memory_fts MATCH ? AND o.entity_id = ? AND %s
 			ORDER BY memory_fts.rank LIMIT ?
-		`, phraseQuery, entityID, collectLimit)
+		`, activeObservationSQL("o")), phraseQuery, entityID, collectLimit)
 		if err == nil {
 			if err := collectFTSRows(rows, candidates, "fts_phrase", maxCandidates); err != nil {
 				return nil, err
@@ -139,13 +140,13 @@ func collectEntityScopedCandidates(db *sql.DB, entityID int64, content string) (
 	// fts — any term.
 	ftsQuery := strings.Join(quoteTerms(cleanTerms), " OR ")
 	if ftsQuery != "" {
-		rows, err := db.Query(`
+		rows, err := db.Query(fmt.Sprintf(`
 			SELECT memory_fts.rowid, memory_fts.rank
 			FROM memory_fts
 			JOIN observations o ON o.id = memory_fts.rowid
-			WHERE memory_fts MATCH ? AND o.entity_id = ? AND o.deleted_at IS NULL
+			WHERE memory_fts MATCH ? AND o.entity_id = ? AND %s
 			ORDER BY memory_fts.rank LIMIT ?
-		`, ftsQuery, entityID, collectLimit)
+		`, activeObservationSQL("o")), ftsQuery, entityID, collectLimit)
 		if err == nil {
 			if err := collectFTSRows(rows, candidates, "fts", maxCandidates); err != nil {
 				return nil, err
@@ -159,11 +160,11 @@ func collectEntityScopedCandidates(db *sql.DB, entityID int64, content string) (
 		if len(candidates) >= maxCandidates {
 			break
 		}
-		if err := collectSimpleIDs(db, candidates, maxCandidates, "content_like", `
+		if err := collectSimpleIDs(db, candidates, maxCandidates, "content_like", fmt.Sprintf(`
 			SELECT o.id FROM observations o
-			WHERE o.entity_id = ? AND o.deleted_at IS NULL AND o.content LIKE ?
+			WHERE o.entity_id = ? AND %s AND o.content LIKE ?
 			ORDER BY o.id LIMIT ?
-		`, entityID, "%"+term+"%", collectLimit); err != nil {
+		`, activeObservationSQL("o")), entityID, "%"+term+"%", collectLimit); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/store/conflict.go
+++ b/internal/store/conflict.go
@@ -127,7 +127,8 @@ func collectEntityScopedCandidates(db *sql.DB, entityID int64, content string) (
 			SELECT memory_fts.rowid, memory_fts.rank
 			FROM memory_fts
 			JOIN observations o ON o.id = memory_fts.rowid
-			WHERE memory_fts MATCH ? AND o.entity_id = ? AND %s
+			JOIN entities e ON o.entity_id = e.id
+			WHERE memory_fts MATCH ? AND o.entity_id = ? AND %s AND e.deleted_at IS NULL
 			ORDER BY memory_fts.rank LIMIT ?
 		`, activeObservationSQL("o")), phraseQuery, entityID, collectLimit)
 		if err == nil {
@@ -144,7 +145,8 @@ func collectEntityScopedCandidates(db *sql.DB, entityID int64, content string) (
 			SELECT memory_fts.rowid, memory_fts.rank
 			FROM memory_fts
 			JOIN observations o ON o.id = memory_fts.rowid
-			WHERE memory_fts MATCH ? AND o.entity_id = ? AND %s
+			JOIN entities e ON o.entity_id = e.id
+			WHERE memory_fts MATCH ? AND o.entity_id = ? AND %s AND e.deleted_at IS NULL
 			ORDER BY memory_fts.rank LIMIT ?
 		`, activeObservationSQL("o")), ftsQuery, entityID, collectLimit)
 		if err == nil {
@@ -162,7 +164,8 @@ func collectEntityScopedCandidates(db *sql.DB, entityID int64, content string) (
 		}
 		if err := collectSimpleIDs(db, candidates, maxCandidates, "content_like", fmt.Sprintf(`
 			SELECT o.id FROM observations o
-			WHERE o.entity_id = ? AND %s AND o.content LIKE ?
+			JOIN entities e ON o.entity_id = e.id
+			WHERE o.entity_id = ? AND %s AND e.deleted_at IS NULL AND o.content LIKE ?
 			ORDER BY o.id LIMIT ?
 		`, activeObservationSQL("o")), entityID, "%"+term+"%", collectLimit); err != nil {
 			return nil, err

--- a/internal/store/conflict_test.go
+++ b/internal/store/conflict_test.go
@@ -128,6 +128,34 @@ func TestDetectEntityConflicts_IgnoresTombstonedObservations(t *testing.T) {
 	}
 }
 
+func TestDetectEntityConflicts_IgnoresExpiredEventObservations(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityID, err := UpsertEntity(db, "API", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	expiredEventID, err := CreateEvent(db, "Expired API note", "", "session", "", "")
+	if err != nil {
+		t.Fatalf("CreateEvent(expired): %v", err)
+	}
+	if _, err := AddObservation(db, entityID, "rate limit is 100 per minute", "user", 1.0, expiredEventID); err != nil {
+		t.Fatalf("AddObservation(expired): %v", err)
+	}
+	if _, err := db.Exec(`UPDATE events SET expires_at = ? WHERE id = ?`, time.Now().Add(-1*time.Hour).UTC().Format(sqliteTimestampLayout), expiredEventID); err != nil {
+		t.Fatalf("expire event: %v", err)
+	}
+
+	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute", memoryHalfLifeWeeks())
+	if err != nil {
+		t.Fatalf("DetectEntityConflicts: %v", err)
+	}
+	if len(hints) != 0 {
+		t.Fatalf("expected 0 hints from expired event observation, got %d: %+v", len(hints), hints)
+	}
+}
+
 func TestDetectEntityConflicts_CapsAtMaxResults(t *testing.T) {
 	t.Parallel()
 	db := newConflictTestDB(t)

--- a/internal/store/conflict_test.go
+++ b/internal/store/conflict_test.go
@@ -128,6 +128,33 @@ func TestDetectEntityConflicts_IgnoresTombstonedObservations(t *testing.T) {
 	}
 }
 
+func TestDetectEntityConflicts_IgnoresTombstonedEntityDrift(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityID, err := UpsertEntity(db, "API", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	if _, err := AddObservation(db, entityID, "rate limit is 100 per minute", "user", 1.0); err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+	// Simulate legacy/partial drift: entity is tombstoned but its observation
+	// row was not. Live candidate collectors must still respect the entity
+	// tombstone guard rather than relying on perfect cascade hygiene.
+	if _, err := db.Exec(`UPDATE entities SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`, entityID); err != nil {
+		t.Fatalf("tombstone entity only: %v", err)
+	}
+
+	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 200 per minute", memoryHalfLifeWeeks())
+	if err != nil {
+		t.Fatalf("DetectEntityConflicts: %v", err)
+	}
+	if len(hints) != 0 {
+		t.Fatalf("expected 0 hints from tombstoned entity drift, got %d: %+v", len(hints), hints)
+	}
+}
+
 func TestDetectEntityConflicts_IgnoresExpiredEventObservations(t *testing.T) {
 	t.Parallel()
 	db := newConflictTestDB(t)

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -207,9 +207,10 @@ func SearchEvents(db *sql.DB, query string, eventType string, dateFrom string, d
 		limit = 20
 	}
 
-	sqlQuery := fmt.Sprintf(`SELECT e.id, e.label, e.event_date, e.event_type, e.context, e.expires_at, e.created_at, COUNT(o.id) AS observation_count
+	sqlQuery := fmt.Sprintf(`SELECT e.id, e.label, e.event_date, e.event_type, e.context, e.expires_at, e.created_at, COUNT(oe.id) AS observation_count
 		FROM events e
 		LEFT JOIN observations o ON o.event_id = e.id AND %s
+		LEFT JOIN entities oe ON oe.id = o.entity_id AND oe.deleted_at IS NULL
 		WHERE %s`, activeObservationSQL("o"), activeEventSQL("e"))
 	args := make([]any, 0, 5)
 	if query != "" {

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -3,7 +3,52 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"strings"
+	"time"
 )
+
+const sqliteTimestampLayout = "2006-01-02 15:04:05"
+
+func activeEventSQL(alias string) string {
+	return fmt.Sprintf(`(%s.expires_at IS NULL OR datetime(%s.expires_at) > CURRENT_TIMESTAMP)`, alias, alias)
+}
+
+func activeObservationSQL(alias string) string {
+	return fmt.Sprintf(`%s.deleted_at IS NULL AND (
+		%s.event_id IS NULL OR EXISTS (
+			SELECT 1 FROM events ev_active
+			WHERE ev_active.id = %s.event_id AND %s
+		)
+	)`, alias, alias, alias, activeEventSQL("ev_active"))
+}
+
+func normalizeExpiresAt(value string) (any, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	layouts := []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999",
+		sqliteTimestampLayout,
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+	}
+	for _, layout := range layouts {
+		var parsed time.Time
+		var err error
+		if layout == time.RFC3339Nano {
+			parsed, err = time.Parse(layout, trimmed)
+		} else {
+			parsed, err = time.ParseInLocation(layout, trimmed, time.UTC)
+		}
+		if err == nil {
+			return parsed.UTC().Format(sqliteTimestampLayout), nil
+		}
+	}
+	return nil, fmt.Errorf("expires_at must be RFC3339 or SQLite timestamp, got %q", value)
+}
 
 type EntityRecord struct {
 	ID         int64  `json:"id"`
@@ -135,13 +180,17 @@ type EventObservationsResult struct {
 }
 
 func CreateEvent(db dbtx, label, eventDate, eventType, context, expiresAt string) (int64, error) {
+	normalizedExpiresAt, err := normalizeExpiresAt(expiresAt)
+	if err != nil {
+		return 0, err
+	}
 	result, err := db.Exec(
 		`INSERT INTO events (label, event_date, event_type, context, expires_at) VALUES (?, ?, ?, ?, ?)`,
 		label,
 		nullableString(eventDate, ""),
 		nullableString(eventType, ""),
 		nullableString(context, ""),
-		nullableString(expiresAt, ""),
+		normalizedExpiresAt,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("create event: %w", err)
@@ -158,10 +207,10 @@ func SearchEvents(db *sql.DB, query string, eventType string, dateFrom string, d
 		limit = 20
 	}
 
-	sqlQuery := `SELECT e.id, e.label, e.event_date, e.event_type, e.context, e.expires_at, e.created_at, COUNT(o.id) AS observation_count
+	sqlQuery := fmt.Sprintf(`SELECT e.id, e.label, e.event_date, e.event_type, e.context, e.expires_at, e.created_at, COUNT(o.id) AS observation_count
 		FROM events e
-		LEFT JOIN observations o ON o.event_id = e.id AND o.deleted_at IS NULL
-		WHERE 1=1`
+		LEFT JOIN observations o ON o.event_id = e.id AND %s
+		WHERE %s`, activeObservationSQL("o"), activeEventSQL("e"))
 	args := make([]any, 0, 5)
 	if query != "" {
 		sqlQuery += ` AND e.label LIKE ?`
@@ -179,7 +228,6 @@ func SearchEvents(db *sql.DB, query string, eventType string, dateFrom string, d
 		sqlQuery += ` AND e.event_date <= ?`
 		args = append(args, dateTo)
 	}
-	sqlQuery += ` AND (e.expires_at IS NULL OR e.expires_at > CURRENT_TIMESTAMP)`
 	sqlQuery += ` GROUP BY e.id ORDER BY e.event_date DESC, e.created_at DESC LIMIT ?`
 	args = append(args, limit)
 
@@ -212,14 +260,14 @@ func GetFullEvent(db *sql.DB, eventID int64, halfLifeWeeks float64) (*FullEventR
 		return nil, nil
 	}
 
-	rows, err := db.Query(`
+	rows, err := db.Query(fmt.Sprintf(`
 		SELECT o.id, o.entity_id, o.content, o.source, o.confidence, o.access_count, o.created_at,
 		       e.name, e.entity_type
 		FROM observations o
 		JOIN entities e ON o.entity_id = e.id
-		WHERE o.event_id = ? AND o.deleted_at IS NULL AND e.deleted_at IS NULL
+		WHERE o.event_id = ? AND %s AND e.deleted_at IS NULL
 		ORDER BY o.created_at ASC
-	`, eventID)
+	`, activeObservationSQL("o")), eventID)
 	if err != nil {
 		return nil, fmt.Errorf("query full event observations: %w", err)
 	}
@@ -291,8 +339,8 @@ func GetObservationsByIDs(db *sql.DB, observationIDs []int64, halfLifeWeeks floa
 			FROM observations o
 			JOIN entities e ON o.entity_id = e.id
 			LEFT JOIN events ev ON o.event_id = ev.id
-			WHERE o.id IN (%s) AND o.deleted_at IS NULL AND e.deleted_at IS NULL
-		`, placeholders(len(chunk))), args...)
+			WHERE o.id IN (%s) AND %s AND e.deleted_at IS NULL
+		`, placeholders(len(chunk)), activeObservationSQL("o")), args...)
 		if err != nil {
 			return GetObservationsResult{}, fmt.Errorf("query observations by ids: %w", err)
 		}
@@ -338,15 +386,15 @@ func GetEventObservations(db *sql.DB, eventID int64, halfLifeWeeks float64) (*Ev
 		return nil, nil
 	}
 
-	rows, err := db.Query(`
+	rows, err := db.Query(fmt.Sprintf(`
 		SELECT o.id, o.entity_id, o.entity_type, o.content, o.source, o.confidence, o.access_count, o.last_accessed, o.deleted_at, o.created_at,
 		       o.event_id, e.name, ev.label, ev.event_date, ev.event_type
 		FROM observations o
 		JOIN entities e ON o.entity_id = e.id
 		LEFT JOIN events ev ON o.event_id = ev.id
-		WHERE o.event_id = ? AND o.deleted_at IS NULL AND e.deleted_at IS NULL
+		WHERE o.event_id = ? AND %s AND e.deleted_at IS NULL
 		ORDER BY o.created_at ASC, o.id ASC
-	`, eventID)
+	`, activeObservationSQL("o")), eventID)
 	if err != nil {
 		return nil, fmt.Errorf("query event observations: %w", err)
 	}
@@ -392,14 +440,14 @@ func GetEntityGraph(db *sql.DB, entityName string, halfLifeWeeks float64) (*Enti
 	entity.EntityType = entityType.String
 	entity.DeletedAt = deletedAt.String
 
-	obsRows, err := db.Query(`
+	obsRows, err := db.Query(fmt.Sprintf(`
 		SELECT o.id, o.entity_id, o.entity_type, o.content, o.source, o.confidence, o.access_count, o.last_accessed, o.deleted_at, o.created_at,
 		       o.event_id, ev.label, ev.event_date, ev.event_type
 		FROM observations o
 		LEFT JOIN events ev ON o.event_id = ev.id
-		WHERE o.entity_id = ? AND o.deleted_at IS NULL
+		WHERE o.entity_id = ? AND %s
 		ORDER BY o.created_at DESC
-	`, entity.ID)
+	`, activeObservationSQL("o")), entity.ID)
 	if err != nil {
 		return nil, fmt.Errorf("query entity observations: %w", err)
 	}
@@ -447,21 +495,21 @@ func ListEntities(db *sql.DB, entityType string, limit int) ([]ListedEntity, err
 	var rows *sql.Rows
 	var err error
 	if entityType != "" {
-		rows, err = db.Query(`
+		rows, err = db.Query(fmt.Sprintf(`
 			SELECT e.id, e.name, e.entity_type, e.deleted_at, e.created_at, e.updated_at, COUNT(o.id) AS observation_count
 			FROM entities e
-			LEFT JOIN observations o ON o.entity_id = e.id AND o.deleted_at IS NULL
+			LEFT JOIN observations o ON o.entity_id = e.id AND %s
 			WHERE e.deleted_at IS NULL AND e.entity_type = ?
 			GROUP BY e.id ORDER BY e.updated_at DESC LIMIT ?
-		`, entityType, limit)
+		`, activeObservationSQL("o")), entityType, limit)
 	} else {
-		rows, err = db.Query(`
+		rows, err = db.Query(fmt.Sprintf(`
 			SELECT e.id, e.name, e.entity_type, e.deleted_at, e.created_at, e.updated_at, COUNT(o.id) AS observation_count
 			FROM entities e
-			LEFT JOIN observations o ON o.entity_id = e.id AND o.deleted_at IS NULL
+			LEFT JOIN observations o ON o.entity_id = e.id AND %s
 			WHERE e.deleted_at IS NULL
 			GROUP BY e.id ORDER BY e.updated_at DESC LIMIT ?
-		`, limit)
+		`, activeObservationSQL("o")), limit)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list entities: %w", err)
@@ -487,7 +535,7 @@ func ListEntities(db *sql.DB, entityType string, limit int) ([]ListedEntity, err
 }
 
 func getEventByID(db *sql.DB, eventID int64) (*EventRecord, error) {
-	rows, err := db.Query(`SELECT id, label, event_date, event_type, context, expires_at, created_at FROM events WHERE id = ?`, eventID)
+	rows, err := db.Query(fmt.Sprintf(`SELECT id, label, event_date, event_type, context, expires_at, created_at FROM events WHERE id = ? AND %s`, activeEventSQL("events")), eventID)
 	if err != nil {
 		return nil, fmt.Errorf("query event by id: %w", err)
 	}

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -231,6 +231,45 @@ func TestEventsAndProvenanceParity(t *testing.T) {
 		}
 	})
 
+	t.Run("tombstoned entity drift disappears from event counts and label candidates", func(t *testing.T) {
+		entityID, err := UpsertEntity(db, "EventLabelTombstoneEntity", "test")
+		if err != nil {
+			t.Fatalf("UpsertEntity() error = %v", err)
+		}
+		eventID, err := CreateEvent(db, "Unique Tombstone Label", "", "session", "", "")
+		if err != nil {
+			t.Fatalf("CreateEvent() error = %v", err)
+		}
+		if _, err := AddObservation(db, entityID, "content that does not contain event label token", "user", 1.0, eventID); err != nil {
+			t.Fatalf("AddObservation() error = %v", err)
+		}
+		// Simulate legacy/partial drift: the entity is tombstoned but its
+		// observation row remains live. Event surfaces and event-label
+		// candidate collection must still respect entity tombstones.
+		if _, err := db.Exec(`UPDATE entities SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`, entityID); err != nil {
+			t.Fatalf("tombstone entity only: %v", err)
+		}
+
+		events, err := SearchEvents(db, "Unique Tombstone Label", "", "", "", 5)
+		if err != nil {
+			t.Fatalf("SearchEvents() error = %v", err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("SearchEvents() returned %d events, want 1: %#v", len(events), events)
+		}
+		if events[0].ObservationCount != 0 {
+			t.Fatalf("SearchEvents() observation_count = %d, want 0 for tombstoned entity drift", events[0].ObservationCount)
+		}
+
+		candidates, err := CollectCandidates(db, "Unique Tombstone Label", 20, 10)
+		if err != nil {
+			t.Fatalf("CollectCandidates() error = %v", err)
+		}
+		if len(candidates) != 0 {
+			t.Fatalf("CollectCandidates() returned tombstoned entity candidates: %#v", candidates)
+		}
+	})
+
 	t.Run("expired event observations disappear from normal read surfaces", func(t *testing.T) {
 		expiredAt := time.Now().Add(-1 * time.Hour).UTC().Format(sqliteTimestampLayout)
 		futureAt := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339Nano)

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 )
 
@@ -227,6 +228,169 @@ func TestEventsAndProvenanceParity(t *testing.T) {
 		}
 		if len(events) == 0 || events[0].ObservationCount != 0 {
 			t.Fatalf("deleted event observation still counted in search events")
+		}
+	})
+
+	t.Run("expired event observations disappear from normal read surfaces", func(t *testing.T) {
+		expiredAt := time.Now().Add(-1 * time.Hour).UTC().Format(sqliteTimestampLayout)
+		futureAt := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339Nano)
+
+		expiredEntityID, err := UpsertEntity(db, "ExpiredEventEntity", "test")
+		if err != nil {
+			t.Fatalf("UpsertEntity(expired) error = %v", err)
+		}
+		expiredEventID, err := CreateEvent(db, "Expired hidden event", "", "session", "", "")
+		if err != nil {
+			t.Fatalf("CreateEvent(expired) error = %v", err)
+		}
+		expiredObservationID, err := AddObservation(db, expiredEntityID, "expiredonlytoken", "user", 1.0, expiredEventID)
+		if err != nil {
+			t.Fatalf("AddObservation(expired) error = %v", err)
+		}
+		if _, err := db.Exec(`UPDATE events SET expires_at = ? WHERE id = ?`, expiredAt, expiredEventID); err != nil {
+			t.Fatalf("expire event error = %v", err)
+		}
+
+		futureEntityID, err := UpsertEntity(db, "FutureEventEntity", "test")
+		if err != nil {
+			t.Fatalf("UpsertEntity(future) error = %v", err)
+		}
+		futureEventID, err := CreateEvent(db, "Future visible event", "", "session", "", futureAt)
+		if err != nil {
+			t.Fatalf("CreateEvent(future) error = %v", err)
+		}
+		futureObservationID, err := AddObservation(db, futureEntityID, "futureonlytoken", "user", 1.0, futureEventID)
+		if err != nil {
+			t.Fatalf("AddObservation(future) error = %v", err)
+		}
+
+		plainEntityID, err := UpsertEntity(db, "PlainEntity", "test")
+		if err != nil {
+			t.Fatalf("UpsertEntity(plain) error = %v", err)
+		}
+		if _, err := AddObservation(db, plainEntityID, "plainonlytoken", "user", 1.0); err != nil {
+			t.Fatalf("AddObservation(plain) error = %v", err)
+		}
+
+		events, err := SearchEvents(db, "Expired hidden event", "", "", "", 5)
+		if err != nil {
+			t.Fatalf("SearchEvents(expired) error = %v", err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("SearchEvents returned expired event: %#v", events)
+		}
+
+		fullExpired, err := GetFullEvent(db, expiredEventID, 12)
+		if err != nil {
+			t.Fatalf("GetFullEvent(expired) error = %v", err)
+		}
+		if fullExpired != nil {
+			t.Fatalf("GetFullEvent returned expired event: %#v", fullExpired)
+		}
+
+		expiredEventObservations, err := GetEventObservations(db, expiredEventID, 12)
+		if err != nil {
+			t.Fatalf("GetEventObservations(expired) error = %v", err)
+		}
+		if expiredEventObservations != nil {
+			t.Fatalf("GetEventObservations returned expired event observations: %#v", expiredEventObservations)
+		}
+
+		expiredByID, err := GetObservationsByIDs(db, []int64{expiredObservationID}, 12)
+		if err != nil {
+			t.Fatalf("GetObservationsByIDs(expired) error = %v", err)
+		}
+		if expiredByID.Total != 0 || len(expiredByID.Observations) != 0 {
+			t.Fatalf("GetObservationsByIDs returned expired observation: %#v", expiredByID)
+		}
+
+		expiredRecall, _, err := SearchMemory(db, "expiredonlytoken", 10, 12)
+		if err != nil {
+			t.Fatalf("SearchMemory(expired) error = %v", err)
+		}
+		if len(expiredRecall) != 0 {
+			t.Fatalf("SearchMemory returned expired observation: %#v", expiredRecall)
+		}
+
+		expiredGraph, err := GetEntityGraph(db, "ExpiredEventEntity", 12)
+		if err != nil {
+			t.Fatalf("GetEntityGraph(expired) error = %v", err)
+		}
+		if expiredGraph == nil {
+			t.Fatalf("GetEntityGraph(expired) returned nil entity graph; want entity with hidden observations")
+		}
+		if len(expiredGraph.Observations) != 0 {
+			t.Fatalf("GetEntityGraph returned expired observations: %#v", expiredGraph.Observations)
+		}
+
+		futureRecall, _, err := SearchMemory(db, "futureonlytoken", 10, 12)
+		if err != nil {
+			t.Fatalf("SearchMemory(future) error = %v", err)
+		}
+		if len(futureRecall) != 1 || futureRecall[0].ID != futureObservationID {
+			t.Fatalf("SearchMemory(future) = %#v, want future observation %d", futureRecall, futureObservationID)
+		}
+
+		plainRecall, _, err := SearchMemory(db, "plainonlytoken", 10, 12)
+		if err != nil {
+			t.Fatalf("SearchMemory(plain) error = %v", err)
+		}
+		if len(plainRecall) != 1 {
+			t.Fatalf("SearchMemory(plain) = %#v, want non-event observation visible", plainRecall)
+		}
+	})
+
+	t.Run("remember event rejects invalid expires_at", func(t *testing.T) {
+		if _, err := CreateEvent(db, "Bad expiry event", "", "session", "", "not-a-timestamp"); err == nil {
+			t.Fatalf("CreateEvent() error = nil, want invalid expires_at rejection")
+		}
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE label = 'Bad expiry event'`).Scan(&count); err != nil {
+			t.Fatalf("count bad expiry events error = %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("invalid expires_at inserted %d event row(s), want 0", count)
+		}
+	})
+
+	t.Run("expired event observations do not satisfy duplicate writes", func(t *testing.T) {
+		entityID, err := UpsertEntity(db, "ExpiredDuplicateEntity", "test")
+		if err != nil {
+			t.Fatalf("UpsertEntity() error = %v", err)
+		}
+		eventID, err := CreateEvent(db, "Expired duplicate event", "", "session", "", "")
+		if err != nil {
+			t.Fatalf("CreateEvent() error = %v", err)
+		}
+		expiredObservationID, err := AddObservation(db, entityID, "duplicateexpirytoken", "user", 1.0, eventID)
+		if err != nil {
+			t.Fatalf("AddObservation(event) error = %v", err)
+		}
+		if _, err := db.Exec(`UPDATE events SET expires_at = ? WHERE id = ?`, time.Now().Add(-1*time.Hour).UTC().Format(sqliteTimestampLayout), eventID); err != nil {
+			t.Fatalf("expire event error = %v", err)
+		}
+
+		newObservationID, err := AddObservation(db, entityID, "duplicateexpirytoken", "user", 1.0)
+		if err != nil {
+			t.Fatalf("AddObservation(non-event duplicate) error = %v", err)
+		}
+		if newObservationID == expiredObservationID {
+			t.Fatalf("AddObservation reused expired observation id %d", expiredObservationID)
+		}
+
+		results, _, err := SearchMemory(db, "duplicateexpirytoken", 10, 12)
+		if err != nil {
+			t.Fatalf("SearchMemory() error = %v", err)
+		}
+		if len(results) != 1 || results[0].ID != newObservationID {
+			t.Fatalf("SearchMemory() = %#v, want only new observation %d", results, newObservationID)
+		}
+
+		if _, err := AddObservation(db, entityID, "hiddenwritetoken", "user", 1.0, eventID); err == nil {
+			t.Fatalf("AddObservation(expired event) error = nil, want rejection")
+		}
+		if _, err := AddObservation(db, entityID, "duplicateexpirytoken", "user", 1.0, eventID); err == nil {
+			t.Fatalf("AddObservation(duplicate content with expired event) error = nil, want event validation before dedupe")
 		}
 	})
 

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -43,8 +43,18 @@ func GetDB(defaultDB *sql.DB, project string) (*sql.DB, error) {
 	}
 
 	dbDir := filepath.Join(resolved, ".memory")
-	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+	created := false
+	if _, err := os.Stat(dbDir); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("stat project memory dir: %w", err)
+		}
+		created = true
+	}
+	if err := os.MkdirAll(dbDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create project memory dir: %w", err)
+	}
+	if created {
+		_ = os.Chmod(dbDir, 0o700)
 	}
 	dbPath := filepath.Join(dbDir, "memory.db")
 	db, err := InitDB(dbPath)

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -206,7 +206,8 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 			}
 			if err := collectSimpleIDs(db, candidates, maxCandidates, "content_like", fmt.Sprintf(`
 				SELECT o.id FROM observations o
-				WHERE %s AND o.content LIKE ?
+				JOIN entities e ON o.entity_id = e.id
+				WHERE %s AND e.deleted_at IS NULL AND o.content LIKE ?
 				ORDER BY o.id LIMIT ?
 			`, activeObservationSQL("o")), "%"+term+"%", collectLimit); err != nil {
 				return nil, err

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -147,7 +147,14 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 
 	if len(terms) > 1 {
 		phraseQuery := `"` + strings.Join(stripQuotes(terms), " ") + `"`
-		rows, err := db.Query(`SELECT rowid, rank FROM memory_fts WHERE memory_fts MATCH ? ORDER BY rank LIMIT ?`, phraseQuery, collectLimit)
+		rows, err := db.Query(fmt.Sprintf(`
+			SELECT memory_fts.rowid, rank
+			FROM memory_fts
+			JOIN observations o ON o.id = memory_fts.rowid
+			JOIN entities e ON e.id = o.entity_id
+			WHERE memory_fts MATCH ? AND %s AND e.deleted_at IS NULL
+			ORDER BY rank LIMIT ?
+		`, activeObservationSQL("o")), phraseQuery, collectLimit)
 		if err == nil {
 			if err := collectFTSRows(rows, candidates, "fts_phrase", maxCandidates); err != nil {
 				return nil, err
@@ -157,7 +164,14 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 
 	ftsQuery := strings.Join(quoteTerms(stripQuotes(terms)), " OR ")
 	if ftsQuery != "" {
-		rows, err := db.Query(`SELECT rowid, rank FROM memory_fts WHERE memory_fts MATCH ? ORDER BY rank LIMIT ?`, ftsQuery, collectLimit)
+		rows, err := db.Query(fmt.Sprintf(`
+			SELECT memory_fts.rowid, rank
+			FROM memory_fts
+			JOIN observations o ON o.id = memory_fts.rowid
+			JOIN entities e ON e.id = o.entity_id
+			WHERE memory_fts MATCH ? AND %s AND e.deleted_at IS NULL
+			ORDER BY rank LIMIT ?
+		`, activeObservationSQL("o")), ftsQuery, collectLimit)
 		if err == nil {
 			if err := collectFTSRows(rows, candidates, "fts", maxCandidates); err != nil {
 				return nil, err
@@ -165,22 +179,22 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 		}
 	}
 
-	if err := collectSimpleIDs(db, candidates, maxCandidates, "entity_exact", `
+	if err := collectSimpleIDs(db, candidates, maxCandidates, "entity_exact", fmt.Sprintf(`
 		SELECT o.id FROM observations o
 		JOIN entities e ON o.entity_id = e.id
-		WHERE o.deleted_at IS NULL AND e.deleted_at IS NULL AND e.name = ? COLLATE NOCASE
+		WHERE %s AND e.deleted_at IS NULL AND e.name = ? COLLATE NOCASE
 		ORDER BY o.id LIMIT ?
-	`, trimmed, collectLimit); err != nil {
+	`, activeObservationSQL("o")), trimmed, collectLimit); err != nil {
 		return nil, err
 	}
 
 	if len(candidates) < maxCandidates {
-		if err := collectSimpleIDs(db, candidates, maxCandidates, "entity_like", `
+		if err := collectSimpleIDs(db, candidates, maxCandidates, "entity_like", fmt.Sprintf(`
 			SELECT o.id FROM observations o
 			JOIN entities e ON o.entity_id = e.id
-			WHERE o.deleted_at IS NULL AND e.deleted_at IS NULL AND e.name LIKE ? COLLATE NOCASE AND e.name != ? COLLATE NOCASE
+			WHERE %s AND e.deleted_at IS NULL AND e.name LIKE ? COLLATE NOCASE AND e.name != ? COLLATE NOCASE
 			ORDER BY o.id LIMIT ?
-		`, "%"+trimmed+"%", trimmed, collectLimit); err != nil {
+		`, activeObservationSQL("o")), "%"+trimmed+"%", trimmed, collectLimit); err != nil {
 			return nil, err
 		}
 	}
@@ -190,11 +204,11 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 			if len(candidates) >= maxCandidates {
 				break
 			}
-			if err := collectSimpleIDs(db, candidates, maxCandidates, "content_like", `
+			if err := collectSimpleIDs(db, candidates, maxCandidates, "content_like", fmt.Sprintf(`
 				SELECT o.id FROM observations o
-				WHERE o.deleted_at IS NULL AND o.content LIKE ?
+				WHERE %s AND o.content LIKE ?
 				ORDER BY o.id LIMIT ?
-			`, "%"+term+"%", collectLimit); err != nil {
+			`, activeObservationSQL("o")), "%"+term+"%", collectLimit); err != nil {
 				return nil, err
 			}
 		}
@@ -205,24 +219,24 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 			if len(candidates) >= maxCandidates {
 				break
 			}
-			if err := collectSimpleIDs(db, candidates, maxCandidates, "type_like", `
+			if err := collectSimpleIDs(db, candidates, maxCandidates, "type_like", fmt.Sprintf(`
 				SELECT o.id FROM observations o
 				JOIN entities e ON o.entity_id = e.id
-				WHERE o.deleted_at IS NULL AND e.deleted_at IS NULL AND e.entity_type LIKE ?
+				WHERE %s AND e.deleted_at IS NULL AND e.entity_type LIKE ?
 				ORDER BY o.id LIMIT ?
-			`, "%"+term+"%", collectLimit); err != nil {
+			`, activeObservationSQL("o")), "%"+term+"%", collectLimit); err != nil {
 				return nil, err
 			}
 		}
 	}
 
 	if len(candidates) < maxCandidates {
-		if err := collectSimpleIDs(db, candidates, maxCandidates, "event_label", `
+		if err := collectSimpleIDs(db, candidates, maxCandidates, "event_label", fmt.Sprintf(`
 			SELECT o.id FROM observations o
 			JOIN events ev ON o.event_id = ev.id
-			WHERE o.deleted_at IS NULL AND ev.label LIKE ?
+			WHERE %s AND %s AND ev.label LIKE ?
 			ORDER BY o.id LIMIT ?
-		`, "%"+trimmed+"%", collectLimit); err != nil {
+		`, activeObservationSQL("o"), activeEventSQL("ev")), "%"+trimmed+"%", collectLimit); err != nil {
 			return nil, err
 		}
 	}
@@ -250,8 +264,8 @@ func HydrateCandidates(db *sql.DB, candidateMap map[int64]*candidate) ([]SearchO
 		FROM observations o
 		JOIN entities e ON o.entity_id = e.id
 		LEFT JOIN events ev ON o.event_id = ev.id
-		WHERE o.id IN (%s) AND o.deleted_at IS NULL AND e.deleted_at IS NULL
-	`, placeholders(len(ids))), args...)
+		WHERE o.id IN (%s) AND %s AND e.deleted_at IS NULL
+	`, placeholders(len(ids)), activeObservationSQL("o")), args...)
 	if err != nil {
 		return nil, fmt.Errorf("hydrate candidates: %w", err)
 	}

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -235,7 +235,8 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 		if err := collectSimpleIDs(db, candidates, maxCandidates, "event_label", fmt.Sprintf(`
 			SELECT o.id FROM observations o
 			JOIN events ev ON o.event_id = ev.id
-			WHERE %s AND %s AND ev.label LIKE ?
+			JOIN entities e ON o.entity_id = e.id
+			WHERE %s AND %s AND e.deleted_at IS NULL AND ev.label LIKE ?
 			ORDER BY o.id LIMIT ?
 		`, activeObservationSQL("o"), activeEventSQL("ev")), "%"+trimmed+"%", collectLimit); err != nil {
 			return nil, err

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -175,7 +175,7 @@ func openSQLite(dbPath string) (*sql.DB, error) {
 		db.Close()
 		return nil, fmt.Errorf("enable foreign keys: %w", err)
 	}
-	_ = os.Chmod(cleanPath, 0o600)
+	hardenSQLiteFiles(cleanPath)
 	return db, nil
 }
 
@@ -188,7 +188,14 @@ func InitDB(dbPath string) (*sql.DB, error) {
 		db.Close()
 		return nil, err
 	}
+	hardenSQLiteFiles(filepath.Clean(dbPath))
 	return db, nil
+}
+
+func hardenSQLiteFiles(dbPath string) {
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm", dbPath + "-journal"} {
+		_ = os.Chmod(path, 0o600)
+	}
 }
 
 func InitSchema(db *sql.DB) error {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -8,7 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	_ "modernc.org/sqlite"
+	sqlite "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
 
 const sqliteDriverName = "sqlite"
@@ -174,6 +175,7 @@ func openSQLite(dbPath string) (*sql.DB, error) {
 		db.Close()
 		return nil, fmt.Errorf("enable foreign keys: %w", err)
 	}
+	_ = os.Chmod(cleanPath, 0o600)
 	return db, nil
 }
 
@@ -332,9 +334,17 @@ func AddObservation(db dbtx, entityID int64, content, source string, confidence 
 		return 0, fmt.Errorf("select entity for observation: %w", err)
 	}
 
+	var eventValue any
+	if len(eventID) > 0 && eventID[0] > 0 {
+		if err := ensureEventIsActive(db, eventID[0]); err != nil {
+			return 0, err
+		}
+		eventValue = eventID[0]
+	}
+
 	var duplicateID int64
 	duplicateErr := db.QueryRow(
-		`SELECT id FROM observations WHERE entity_id = ? AND content = ? AND deleted_at IS NULL`,
+		fmt.Sprintf(`SELECT o.id FROM observations o WHERE o.entity_id = ? AND o.content = ? AND %s`, activeObservationSQL("o")),
 		entityID,
 		content,
 	).Scan(&duplicateID)
@@ -343,11 +353,6 @@ func AddObservation(db dbtx, entityID int64, content, source string, confidence 
 	}
 	if !errors.Is(duplicateErr, sql.ErrNoRows) {
 		return 0, fmt.Errorf("lookup duplicate observation: %w", duplicateErr)
-	}
-
-	var eventValue any
-	if len(eventID) > 0 && eventID[0] > 0 {
-		eventValue = eventID[0]
 	}
 
 	result, err := db.Exec(
@@ -378,6 +383,21 @@ func AddObservation(db dbtx, entityID int64, content, source string, confidence 
 	}
 
 	return observationID, nil
+}
+
+func ensureEventIsActive(db dbtx, eventID int64) error {
+	var id int64
+	err := db.QueryRow(
+		fmt.Sprintf(`SELECT e.id FROM events e WHERE e.id = ? AND %s`, activeEventSQL("e")),
+		eventID,
+	).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("event %d not found or expired", eventID)
+	}
+	if err != nil {
+		return fmt.Errorf("select active event: %w", err)
+	}
+	return nil
 }
 
 func TouchObservations(db *sql.DB, observationIDs []int64) error {
@@ -412,7 +432,14 @@ func SearchObservationIDs(db *sql.DB, query string) ([]int64, error) {
 		return nil, nil
 	}
 
-	rows, err := db.Query(`SELECT rowid FROM memory_fts WHERE memory_fts MATCH ? ORDER BY rank`, quoteFTSTerms(ftsQuery))
+	rows, err := db.Query(fmt.Sprintf(`
+		SELECT memory_fts.rowid
+		FROM memory_fts
+		JOIN observations o ON o.id = memory_fts.rowid
+		JOIN entities e ON e.id = o.entity_id
+		WHERE memory_fts MATCH ? AND %s AND e.deleted_at IS NULL
+		ORDER BY memory_fts.rank
+	`, activeObservationSQL("o")), quoteFTSTerms(ftsQuery))
 	if err != nil {
 		return nil, fmt.Errorf("fts search: %w", err)
 	}
@@ -584,7 +611,18 @@ func RejectsOrphanObservationInsert(db *sql.DB) (bool, error) {
 	if err == nil {
 		return false, nil
 	}
+	if !isForeignKeyConstraint(err) {
+		return false, fmt.Errorf("orphan observation insert failed for non-foreign-key reason: %w", err)
+	}
 	return true, nil
+}
+
+func isForeignKeyConstraint(err error) bool {
+	var sqliteErr *sqlite.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+	return sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_FOREIGNKEY
 }
 
 func quoteFTSTerms(query string) string {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -80,6 +80,38 @@ func TestInitDBCreatesPrivateDatabaseFile(t *testing.T) {
 	}
 }
 
+func TestInitDBHardensSQLiteSidecarFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not portable on Windows")
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "sidecars.db")
+	db, err := InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	entityID, err := UpsertEntity(db, "SidecarEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	if _, err := AddObservation(db, entityID, "sidecar mode probe", "user", 1.0); err != nil {
+		t.Fatalf("AddObservation() error = %v", err)
+	}
+
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		path := dbPath + suffix
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat sqlite file %s error = %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Fatalf("sqlite file %s mode = %o, want 600", path, got)
+		}
+	}
+}
+
 func TestProjectDBCreatesPrivateMemoryDirectory(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX file modes are not portable on Windows")

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1,8 +1,12 @@
 package store
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 )
 
 func TestSQLiteCanary(t *testing.T) {
@@ -29,6 +33,168 @@ func TestSQLiteCanary(t *testing.T) {
 	}
 	if result.PersistedObservationCount != 1 {
 		t.Fatalf("PersistedObservationCount = %d, want 1", result.PersistedObservationCount)
+	}
+}
+
+func TestRejectsOrphanObservationInsertOnlyAcceptsForeignKeyFailure(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "fk-specific.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	rejected, err := RejectsOrphanObservationInsert(db)
+	if err != nil {
+		t.Fatalf("RejectsOrphanObservationInsert() error = %v", err)
+	}
+	if !rejected {
+		t.Fatalf("RejectsOrphanObservationInsert() = false, want true")
+	}
+	if isForeignKeyConstraint(errors.New("database is locked")) {
+		t.Fatalf("isForeignKeyConstraint accepted a non-SQLite FK error")
+	}
+}
+
+func TestInitDBCreatesPrivateDatabaseFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not portable on Windows")
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "private.db")
+	db, err := InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat db file error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("db file mode = %o, want 600", got)
+	}
+}
+
+func TestProjectDBCreatesPrivateMemoryDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not portable on Windows")
+	}
+
+	defaultDB, err := InitDB(filepath.Join(t.TempDir(), "default.db"))
+	if err != nil {
+		t.Fatalf("InitDB(default) error = %v", err)
+	}
+	defer defaultDB.Close()
+	t.Cleanup(func() {
+		if err := ResetProjectDBs(); err != nil {
+			t.Fatalf("ResetProjectDBs() error = %v", err)
+		}
+	})
+
+	projectRoot := filepath.Join(t.TempDir(), "project")
+	if _, err := GetDB(defaultDB, projectRoot); err != nil {
+		t.Fatalf("GetDB(project) error = %v", err)
+	}
+
+	memoryDir := filepath.Join(projectRoot, ".memory")
+	info, err := os.Stat(memoryDir)
+	if err != nil {
+		t.Fatalf("stat project .memory dir error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("project .memory dir mode = %o, want 700", got)
+	}
+
+	dbInfo, err := os.Stat(filepath.Join(memoryDir, "memory.db"))
+	if err != nil {
+		t.Fatalf("stat project memory.db error = %v", err)
+	}
+	if got := dbInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("project memory.db mode = %o, want 600", got)
+	}
+}
+
+func TestProjectDBDoesNotTightenExistingMemoryDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not portable on Windows")
+	}
+
+	defaultDB, err := InitDB(filepath.Join(t.TempDir(), "default.db"))
+	if err != nil {
+		t.Fatalf("InitDB(default) error = %v", err)
+	}
+	defer defaultDB.Close()
+	t.Cleanup(func() {
+		if err := ResetProjectDBs(); err != nil {
+			t.Fatalf("ResetProjectDBs() error = %v", err)
+		}
+	})
+
+	projectRoot := filepath.Join(t.TempDir(), "project-existing")
+	memoryDir := filepath.Join(projectRoot, ".memory")
+	if err := os.MkdirAll(memoryDir, 0o755); err != nil {
+		t.Fatalf("mkdir existing project .memory error = %v", err)
+	}
+	if err := os.Chmod(memoryDir, 0o755); err != nil {
+		t.Fatalf("chmod existing project .memory error = %v", err)
+	}
+
+	if _, err := GetDB(defaultDB, projectRoot); err != nil {
+		t.Fatalf("GetDB(project) error = %v", err)
+	}
+
+	info, err := os.Stat(memoryDir)
+	if err != nil {
+		t.Fatalf("stat project .memory dir error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("existing project .memory dir mode = %o, want preserved 755", got)
+	}
+
+	dbInfo, err := os.Stat(filepath.Join(memoryDir, "memory.db"))
+	if err != nil {
+		t.Fatalf("stat project memory.db error = %v", err)
+	}
+	if got := dbInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("project memory.db mode = %o, want 600", got)
+	}
+}
+
+func TestSearchObservationIDsHonorsExpiryGuard(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "search-ids-expiry.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	entityID, err := UpsertEntity(db, "SearchIDsExpiry", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	expiredEventID, err := CreateEvent(db, "Expired search ids event", "", "session", "", "")
+	if err != nil {
+		t.Fatalf("CreateEvent(expired) error = %v", err)
+	}
+	if _, err := AddObservation(db, entityID, "expiredsearchidtoken", "user", 1.0, expiredEventID); err != nil {
+		t.Fatalf("AddObservation(expired) error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE events SET expires_at = ? WHERE id = ?`, time.Now().Add(-1*time.Hour).UTC().Format(sqliteTimestampLayout), expiredEventID); err != nil {
+		t.Fatalf("expire event error = %v", err)
+	}
+
+	ids, err := SearchObservationIDs(db, "expiredsearchidtoken")
+	if err != nil {
+		t.Fatalf("SearchObservationIDs() error = %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("SearchObservationIDs returned expired observation ids: %#v", ids)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Treat event expiry as a lifecycle guard across recall/provenance read surfaces and prevent hidden writes/dedupes against expired observations.
- Harden local memory storage defaults with private directory/file permissions without mutating existing parent directories.
- Make SQLite FK canary reason-specific and document the pre-v1 semantic hardening decision.

## Validation
- go test ./...
- go vet ./...
- VSCode diagnostics: no issues
- Codex/Kimi local review follow-ups completed; final Codex blocker recheck found no blockers/risks.