### PR TITLE
fix(store): clamp future-dated decay and escape LIKE wildcards

### DIFF
--- a/internal/store/conflict.go
+++ b/internal/store/conflict.go
@@ -165,9 +165,9 @@ func collectEntityScopedCandidates(db *sql.DB, entityID int64, content string) (
 		if err := collectSimpleIDs(db, candidates, maxCandidates, "content_like", fmt.Sprintf(`
 			SELECT o.id FROM observations o
 			JOIN entities e ON o.entity_id = e.id
-			WHERE o.entity_id = ? AND %s AND e.deleted_at IS NULL AND o.content LIKE ?
+			WHERE o.entity_id = ? AND %s AND e.deleted_at IS NULL AND o.content LIKE ? ESCAPE '\'
 			ORDER BY o.id LIMIT ?
-		`, activeObservationSQL("o")), entityID, "%"+term+"%", collectLimit); err != nil {
+		`, activeObservationSQL("o")), entityID, "%"+escapeLikePattern(term)+"%", collectLimit); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -214,8 +214,8 @@ func SearchEvents(db *sql.DB, query string, eventType string, dateFrom string, d
 		WHERE %s`, activeObservationSQL("o"), activeEventSQL("e"))
 	args := make([]any, 0, 5)
 	if query != "" {
-		sqlQuery += ` AND e.label LIKE ?`
-		args = append(args, "%"+query+"%")
+		sqlQuery += ` AND e.label LIKE ? ESCAPE '\'`
+		args = append(args, "%"+escapeLikePattern(query)+"%")
 	}
 	if eventType != "" {
 		sqlQuery += ` AND e.event_type = ?`

--- a/internal/store/events_test.go
+++ b/internal/store/events_test.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSearchEventsCountsObservationsCorrectly(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "events-count.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	eventID, err := CreateEvent(db, "Standup", "2026-04-26", "meeting", "", "")
+	if err != nil {
+		t.Fatalf("CreateEvent() error = %v", err)
+	}
+
+	entityA, err := UpsertEntity(db, "Alice", "person")
+	if err != nil {
+		t.Fatalf("UpsertEntity(Alice) error = %v", err)
+	}
+	entityB, err := UpsertEntity(db, "Bob", "person")
+	if err != nil {
+		t.Fatalf("UpsertEntity(Bob) error = %v", err)
+	}
+
+	if _, err := AddObservation(db, entityA, "discussed API design", "user", 1.0, eventID); err != nil {
+		t.Fatalf("AddObservation(Alice,1) error = %v", err)
+	}
+	if _, err := AddObservation(db, entityA, "reviewed PR #42", "user", 1.0, eventID); err != nil {
+		t.Fatalf("AddObservation(Alice,2) error = %v", err)
+	}
+	if _, err := AddObservation(db, entityB, "raised infra concern", "user", 1.0, eventID); err != nil {
+		t.Fatalf("AddObservation(Bob) error = %v", err)
+	}
+
+	results, err := SearchEvents(db, "", "", "", "", 10)
+	if err != nil {
+		t.Fatalf("SearchEvents() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("SearchEvents() returned %d results, want 1", len(results))
+	}
+	if results[0].ObservationCount != 3 {
+		t.Fatalf("SearchEvents() ObservationCount = %d, want 3", results[0].ObservationCount)
+	}
+}

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -106,7 +106,11 @@ func DecayedConfidence(createdAt string, confidence float64, accessCount int64, 
 	if stability <= 0 {
 		return confidence
 	}
-	return confidence * math.Pow(0.5, ageWeeks/stability)
+	result := confidence * math.Pow(0.5, ageWeeks/stability)
+	if result > confidence {
+		return confidence
+	}
+	return result
 }
 
 func FTSPositionScore(position, totalFtsResults int) float64 {
@@ -192,9 +196,9 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 		if err := collectSimpleIDs(db, candidates, maxCandidates, "entity_like", fmt.Sprintf(`
 			SELECT o.id FROM observations o
 			JOIN entities e ON o.entity_id = e.id
-			WHERE %s AND e.deleted_at IS NULL AND e.name LIKE ? COLLATE NOCASE AND e.name != ? COLLATE NOCASE
+			WHERE %s AND e.deleted_at IS NULL AND e.name LIKE ? ESCAPE '\' AND e.name != ? COLLATE NOCASE
 			ORDER BY o.id LIMIT ?
-		`, activeObservationSQL("o")), "%"+trimmed+"%", trimmed, collectLimit); err != nil {
+		`, activeObservationSQL("o")), "%"+escapeLikePattern(trimmed)+"%", trimmed, collectLimit); err != nil {
 			return nil, err
 		}
 	}
@@ -207,9 +211,9 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 			if err := collectSimpleIDs(db, candidates, maxCandidates, "content_like", fmt.Sprintf(`
 				SELECT o.id FROM observations o
 				JOIN entities e ON o.entity_id = e.id
-				WHERE %s AND e.deleted_at IS NULL AND o.content LIKE ?
+				WHERE %s AND e.deleted_at IS NULL AND o.content LIKE ? ESCAPE '\'
 				ORDER BY o.id LIMIT ?
-			`, activeObservationSQL("o")), "%"+term+"%", collectLimit); err != nil {
+			`, activeObservationSQL("o")), "%"+escapeLikePattern(term)+"%", collectLimit); err != nil {
 				return nil, err
 			}
 		}
@@ -223,9 +227,9 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 			if err := collectSimpleIDs(db, candidates, maxCandidates, "type_like", fmt.Sprintf(`
 				SELECT o.id FROM observations o
 				JOIN entities e ON o.entity_id = e.id
-				WHERE %s AND e.deleted_at IS NULL AND e.entity_type LIKE ?
+				WHERE %s AND e.deleted_at IS NULL AND e.entity_type LIKE ? ESCAPE '\'
 				ORDER BY o.id LIMIT ?
-			`, activeObservationSQL("o")), "%"+term+"%", collectLimit); err != nil {
+			`, activeObservationSQL("o")), "%"+escapeLikePattern(term)+"%", collectLimit); err != nil {
 				return nil, err
 			}
 		}
@@ -236,9 +240,9 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 			SELECT o.id FROM observations o
 			JOIN events ev ON o.event_id = ev.id
 			JOIN entities e ON o.entity_id = e.id
-			WHERE %s AND %s AND e.deleted_at IS NULL AND ev.label LIKE ?
+			WHERE %s AND %s AND e.deleted_at IS NULL AND ev.label LIKE ? ESCAPE '\'
 			ORDER BY o.id LIMIT ?
-		`, activeObservationSQL("o"), activeEventSQL("ev")), "%"+trimmed+"%", collectLimit); err != nil {
+		`, activeObservationSQL("o"), activeEventSQL("ev")), "%"+escapeLikePattern(trimmed)+"%", collectLimit); err != nil {
 			return nil, err
 		}
 	}
@@ -576,6 +580,15 @@ func quoteTerms(terms []string) []string {
 		quoted = append(quoted, `"`+term+`"`)
 	}
 	return quoted
+}
+
+// escapeLikePattern escapes SQL LIKE wildcards (% and _) and the escape
+// character itself so user input is treated as literal text.
+func escapeLikePattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "%", "\\%")
+	s = strings.ReplaceAll(s, "_", "\\_")
+	return s
 }
 
 func parseSQLiteTime(value string) (time.Time, error) {

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDecayedConfidence_ClampedToOriginal(t *testing.T) {
+	t.Parallel()
+
+	// Future timestamp must not amplify beyond original confidence.
+	future := time.Now().UTC().Add(7 * 24 * time.Hour).Format("2006-01-02 15:04:05")
+	got := DecayedConfidence(future, 0.9, 0, 12)
+	if got > 0.9 {
+		t.Fatalf("DecayedConfidence(future) = %f, want <= 0.9", got)
+	}
+
+	// Recent past timestamp must stay within a tight band of the original
+	// confidence (no clamp needed, just no amplification).
+	recent := time.Now().UTC().Add(-1 * time.Second).Format("2006-01-02 15:04:05")
+	gotNow := DecayedConfidence(recent, 0.9, 0, 12)
+	if gotNow > 0.9 {
+		t.Fatalf("DecayedConfidence(recent) = %f, want <= 0.9", gotNow)
+	}
+	if gotNow < 0.899 {
+		t.Fatalf("DecayedConfidence(recent) = %f, want >= 0.899", gotNow)
+	}
+}
+
+func TestEscapeLikePattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"hello", "hello"},
+		{"50%", `50\%`},
+		{"test_a", `test\_a`},
+		{"a%b_c", `a\%b\_c`},
+		{`a\%b`, `a\\\%b`},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := escapeLikePattern(tt.input)
+		if got != tt.expected {
+			t.Fatalf("escapeLikePattern(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestEscapeLikePattern_QueryVerification(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "like-escape.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	entityID, err := UpsertEntity(db, "LikeEscapeEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+
+	// Content that differs only by a literal % vs an extra 0 digit.
+	if _, err := AddObservation(db, entityID, "discount is 50% off", "user", 1.0); err != nil {
+		t.Fatalf("AddObservation(50%%) error = %v", err)
+	}
+	if _, err := AddObservation(db, entityID, "discount is 500 off", "user", 1.0); err != nil {
+		t.Fatalf("AddObservation(500) error = %v", err)
+	}
+
+	// Direct SQL query with escaped pattern — this isolates the LIKE layer
+	// from FTS noise. The pattern "50%" escaped must match only "50% off".
+	pattern := "%" + escapeLikePattern("50%") + "%"
+	rows, err := db.Query("SELECT content FROM observations WHERE content LIKE ? ESCAPE '\\'", pattern)
+	if err != nil {
+		t.Fatalf("direct LIKE query error = %v", err)
+	}
+	defer rows.Close()
+
+	var matches []string
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			t.Fatalf("scan error = %v", err)
+		}
+		matches = append(matches, content)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate error = %v", err)
+	}
+
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match for escaped '50%%', got %d: %v", len(matches), matches)
+	}
+	if matches[0] != "discount is 50% off" {
+		t.Fatalf("match = %q, want %q", matches[0], "discount is 50% off")
+	}
+}


### PR DESCRIPTION
## Summary

Two correctness hardening fixes for the search and scoring pipeline:

1. **Clamp future-dated decay amplification** — `DecayedConfidence` with a future `createdAt` (clock skew) computed `Pow(0.5, negative) > 1`, inflating effective confidence beyond the original value. Now clamped to `<= confidence`.

2. **Escape SQL LIKE wildcards** — user queries containing `%` or `_` were passed literally into `LIKE` patterns, causing unexpected semantic expansion (e.g. `50%` matching `500`). Added `escapeLikePattern()` helper + `ESCAPE '\\'` to all LIKE queries across `search.go`, `events.go`, and `conflict.go`.

## Files changed

| File | Change |
|------|--------|
| `internal/store/search.go` | Clamp decay; add `escapeLikePattern`; update 4 LIKE queries |
| `internal/store/events.go` | Update `SearchEvents` label LIKE |
| `internal/store/conflict.go` | Update conflict detection content LIKE |
| `internal/store/search_test.go` | Tests for clamp, escape helper, end-to-end SQL LIKE |
| `internal/store/events_test.go` | Regression guard for `SearchEvents` observation count |

## Testing

- `go test ./...` passes (all packages)
- New tests cover both fix paths directly