### PR TITLE
fix(telemetry): redact malformed sensitive arguments

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -15,6 +15,7 @@
 - Telemetry is opt-in (`MEMORY_TELEMETRY_PATH`) and never affects the tool call success path. Init failure logs a single warning to stderr and disables telemetry for the session; the main memory DB is unaffected.
 - Telemetry data lives in its own SQLite file, physically separate from the memory database. No foreign keys, no joins, no shared lifecycle.
 - When `MEMORY_TELEMETRY_PRIVACY=strict`, entity names, queries, and event labels must be sha256-hashed before reaching disk. Observation/content values are always reduced to `<N chars>` regardless of mode.
+- Telemetry summaries and validation errors must never include raw sensitive payloads. This applies before type validation too: malformed `observation`, `content`, `context`, `facts`, or `observations` values are redacted by key and JSON type, not serialized as received.
 - New memory directories must be private by default (`0700`) and SQLite DB files plus SQLite sidecars (`-wal`, `-shm`, `-journal`) are best-effort hardened to `0600` on POSIX filesystems.
 
 ## Active Debt
@@ -36,6 +37,36 @@ Fix (calibration protocol):
   5. After adjustment, reset the sample window and re-measure.
   6. Split telemetry by `tool_calls.db_scope` before computing the ratio. Global memory uses `MEMORY_HALF_LIFE_WEEKS` (12 by default) and project memory uses `PROJECT_MEMORY_HALF_LIFE_WEEKS` (52 by default), so observations of the same age decay differently across scopes and produce systematically different composite scores. Mixing both scopes into one ratio averages two distributions and pins a threshold that fits neither. The schema already exposes `db_scope`; the obligation is on the analysis path. Same goes for any future per-instance half-life override.
 Done when: either the threshold has been confirmed twice in a row at the same value with the ratio inside [0.5, 0.9], or telemetry has shown a clear reason to redesign the hint (e.g., lexical detection consistently misses semantic conflicts and a pure-Go embedding path becomes available).
+
+- `remember` conflict detection and observation insert are not wrapped in one transaction.
+Trigger: A future write path relies on conflict hints as an atomic statement about the exact state being committed, or `MaxOpenConns(1)` changes.
+Blast radius: Conflict hints can be computed against a state that is not the final committed write state; future concurrency changes could turn this from benign sequencing into stale hints.
+Fix: Wrap `UpsertEntity`, `DetectEntityConflicts`, and `AddObservation` for a single `remember` call in one transaction, preserving the current "detect before insert" self-match invariant.
+Done when: a regression test proves the transactional path still returns pre-insert conflicts and commits/rolls back as a unit.
+
+- `relate` can leave newly upserted entities behind if relation insertion fails after entity creation.
+Trigger: A non-unique relation insert or future validation/constraint failure happens after one or both endpoint entities were created for the call.
+Blast radius: Failed relation calls can leave orphan-ish entity rows that look intentional to future recall/list surfaces.
+Fix: Wrap both endpoint `UpsertEntity` calls and the relation insert in one transaction; preserve the existing "already exists" response for unique conflicts.
+Done when: a regression test forces relation insert failure and proves no new endpoint entities survive unless the relation is created or already existed.
+
+- FTS channel query errors in recall/conflict candidate collection are silently swallowed and degrade to non-FTS channels.
+Trigger: FTS table corruption, query syntax drift, driver behavior change, or migration bug breaks FTS while LIKE/entity channels still return results.
+Blast radius: Search quality and conflict hints degrade without an operational signal; telemetry calibration can misread an FTS outage as threshold or model behavior.
+Fix: Surface FTS degradation through telemetry/metrics or a structured warning path without making normal recall fail when fallback channels are available.
+Done when: tests cover FTS query failure producing an observable degraded signal while preserving fallback search behavior.
+
+- Confidence values above `1.0` are accepted despite the MCP contract describing `0.0-1.0`.
+Trigger: A caller passes `confidence > 1.0` to `remember`, `remember_batch`, or `remember_event`.
+Blast radius: Stored confidence and derived `effective_confidence` exceed the intended range, inflating composite ranking and conflict scores.
+Fix: Reject or clamp out-of-range confidence consistently at the tool validation/store boundary; document the chosen behavior in `API_CONTRACT.md` if user-visible.
+Done when: tests cover negative, zero, in-range, and above-one confidence across single and batch/event write paths.
+
+- `relate` permits self-referencing relations.
+Trigger: A caller sends `relate(from: X, to: X, relation_type: R)`.
+Blast radius: Entity graphs can contain meaningless self-loops in both outgoing and incoming relations, confusing downstream consumers and review/debug output.
+Fix: Reject self-relations in validation; optionally add a SQLite `CHECK (from_entity_id != to_entity_id)` in the next migration path.
+Done when: a regression test proves self-relations are rejected before any DB mutation.
 
 - The Go port now replays the shared product fixtures locally, but still lacks an automated Node-vs-Go dual-runtime comparison in CI.
 Trigger: Trusting Go-only fixture replay as full parity proof.
@@ -64,6 +95,18 @@ Done when: FTS-specific parity tests pass across the release matrix.
 - Cross-build CI currently compiles with `CGO_ENABLED=0`; that matches the single-binary intent, but the runtime FTS proof is still stronger on real test runs than on cross-compiled artifacts alone.
 
 ### P2
+
+- Project-scoped DB handles are cached indefinitely for the process lifetime.
+Trigger: A long-running MCP server touches many distinct project paths over time.
+Blast radius: The `projectDBs` map and open SQLite file descriptors grow until shutdown; small personal use is fine, broad workspace use can leak resources.
+Fix: Add a bounded cache with lazy close/eviction, or an explicit max cap with deterministic close behavior.
+Done when: a regression test opens more than the cap and proves older project DB handles are closed/evicted without breaking active global storage.
+
+- `SearchEvents` label wildcard escaping lacks direct regression coverage.
+Trigger: A future change edits `SearchEvents` or `escapeLikePattern` and breaks literal `%`, `_`, or `\` searches for event labels.
+Blast radius: The PR #14 event-label hardening can regress while the current event count test still passes because it uses an empty query.
+Fix: Add a `SearchEvents` test with labels containing LIKE wildcards and backslashes, proving literal matching excludes wildcard-expanded neighbors.
+Done when: the test fails if `ESCAPE '\'` or `escapeLikePattern(query)` is removed from the event-label path.
 
 - Schema migrations are still inline `ALTER TABLE` statements guarded by duplicate-schema string matching.
 Trigger: Adding more migrations before replacing the guard with explicit migration tracking.

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -279,11 +279,12 @@ func validateStringArguments(def toolDefinition, args map[string]any) map[string
 		if _, ok := value.(string); ok {
 			continue
 		}
+		got := argumentJSONTypeName(value)
 		return map[string]any{
-			"error": fmt.Sprintf("Invalid argument type: '%s' must be a string, got %T", key, value),
+			"error": fmt.Sprintf("Invalid argument type: '%s' must be a string, got %s", key, got),
 			"tool":  def.Name,
 			"received": map[string]any{
-				key: value,
+				key: fmt.Sprintf("<%s>", got),
 			},
 			"RetryArguments": map[string]string{
 				key: fmt.Sprintf("string — %s", propertyDescription(def, key)),
@@ -291,6 +292,25 @@ func validateStringArguments(def toolDefinition, args map[string]any) map[string
 		}
 	}
 	return nil
+}
+
+func argumentJSONTypeName(value any) string {
+	switch value.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return "number"
+	case string:
+		return "string"
+	case []any:
+		return "array"
+	case map[string]any:
+		return "object"
+	default:
+		return fmt.Sprintf("%T", value)
+	}
 }
 
 func retryArguments(def toolDefinition) map[string]string {

--- a/internal/mcpserver/telemetry_integration_test.go
+++ b/internal/mcpserver/telemetry_integration_test.go
@@ -232,6 +232,102 @@ func TestTelemetryStrictModeHashesIdentifiersEndToEnd(t *testing.T) {
 	}
 }
 
+func TestTelemetryRedactsMalformedSensitiveArgumentsEndToEnd(t *testing.T) {
+	telePath := filepath.Join(t.TempDir(), "strict-malformed-telemetry.db")
+	tele := telemetry.InitIfEnabled(telePath, true)
+	if tele == nil {
+		t.Fatalf("telemetry InitIfEnabled(strict) returned nil")
+	}
+
+	runtime, err := New(Config{DBPath: filepath.Join(t.TempDir(), "memory.db"), Telemetry: tele})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	session, stop := startTelemetrySession(t, runtime)
+	defer stop()
+	ctx := context.Background()
+	sentinel := "SECRET-MALFORMED-PAYLOAD"
+
+	calls := []struct {
+		name string
+		args map[string]any
+	}{
+		{
+			name: "remember",
+			args: map[string]any{
+				"entity":      "MalformedTelemetryEntity",
+				"observation": map[string]any{"secret": sentinel},
+			},
+		},
+		{
+			name: "remember_event",
+			args: map[string]any{
+				"label":        "MalformedTelemetryEvent",
+				"event_date":   "2026-04-26",
+				"context":      []any{sentinel},
+				"observations": []any{map[string]any{"entity": "Nested", "observation": sentinel}},
+			},
+		},
+		{
+			name: "remember_batch",
+			args: map[string]any{
+				"facts": map[string]any{"secret": sentinel},
+			},
+		},
+	}
+
+	for _, tc := range calls {
+		result, err := session.CallTool(ctx, &mcp.CallToolParams{Name: tc.name, Arguments: tc.args})
+		if err != nil {
+			t.Fatalf("CallTool(%s) error = %v", tc.name, err)
+		}
+		if !result.IsError {
+			t.Fatalf("CallTool(%s) returned success for malformed sensitive args", tc.name)
+		}
+		if text := toolTextContent(t, result); strings.Contains(text, sentinel) {
+			t.Fatalf("CallTool(%s) error payload leaked malformed sensitive value: %s", tc.name, text)
+		}
+	}
+
+	stop()
+
+	rdb, err := sql.Open("sqlite", "file:"+filepath.Clean(telePath)+"?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatalf("open strict telemetry db: %v", err)
+	}
+	defer rdb.Close()
+
+	rows, err := rdb.Query(`SELECT tool, args_summary, is_error FROM tool_calls ORDER BY id`)
+	if err != nil {
+		t.Fatalf("query tool_calls: %v", err)
+	}
+	defer rows.Close()
+
+	var rowCount int
+	for rows.Next() {
+		rowCount++
+		var tool string
+		var argsSummary sql.NullString
+		var isErr int
+		if err := rows.Scan(&tool, &argsSummary, &isErr); err != nil {
+			t.Fatalf("scan tool_calls row: %v", err)
+		}
+		if isErr != 1 {
+			t.Fatalf("tool_calls row for %s is_error = %d, want 1", tool, isErr)
+		}
+		if strings.Contains(argsSummary.String, sentinel) {
+			t.Fatalf("tool_calls args_summary for %s leaked malformed sensitive value: %s", tool, argsSummary.String)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate tool_calls: %v", err)
+	}
+	if rowCount != len(calls) {
+		t.Fatalf("tool_calls count = %d, want %d", rowCount, len(calls))
+	}
+}
+
 // TestStepGateConflictHintEndToEndLoop is the Step 4.1 Gate fixture.
 // It drives the full conflict-hint loop through the MCP stdio surface
 // in-process and asserts every part of the promised behavior lands:

--- a/internal/telemetry/sanitize.go
+++ b/internal/telemetry/sanitize.go
@@ -24,12 +24,15 @@ func encodeNoEscape(v any) (string, error) {
 // SanitizeArgs produces the args_summary string for a tool call.
 //
 // Rules:
-//   - "observation", "content", "context" string values are replaced with
-//     "<N chars>" (length only, never content)
+//   - "observation", "content", "context" values are replaced with a
+//     content-free marker. String values keep only their rune count; invalid
+//     non-string values keep only their JSON type.
 //   - "facts" and "observations" arrays are replaced with "<N facts>" /
-//     "<N observations>" (count only, never contents)
+//     "<N observations>" (count only, never contents). Invalid non-array
+//     values keep only their JSON type.
 //   - "entity", "from", "to", "label", "query" string values are hashed when
-//     strict is true; left unchanged otherwise
+//     strict is true; left unchanged otherwise. Invalid non-string identifier
+//     values keep only their JSON type because they may contain nested secrets.
 //   - all other fields pass through unchanged
 func SanitizeArgs(args map[string]any, strict bool) string {
 	if args == nil {
@@ -43,25 +46,25 @@ func SanitizeArgs(args map[string]any, strict bool) string {
 				safe[k] = fmt.Sprintf("<%d chars>", utf8.RuneCountInString(s))
 				continue
 			}
-			safe[k] = v
+			safe[k] = redactedJSONType(v)
 		case "facts":
 			if arr, ok := v.([]any); ok {
 				safe[k] = fmt.Sprintf("<%d facts>", len(arr))
 				continue
 			}
-			safe[k] = v
+			safe[k] = redactedJSONType(v)
 		case "observations":
 			if arr, ok := v.([]any); ok {
 				safe[k] = fmt.Sprintf("<%d observations>", len(arr))
 				continue
 			}
-			safe[k] = v
+			safe[k] = redactedJSONType(v)
 		case "entity", "from", "to", "label", "query":
 			if s, ok := v.(string); ok {
 				safe[k] = hashIfStrict(s, strict)
 				continue
 			}
-			safe[k] = v
+			safe[k] = redactedJSONType(v)
 		default:
 			safe[k] = v
 		}
@@ -71,6 +74,29 @@ func SanitizeArgs(args map[string]any, strict bool) string {
 		return ""
 	}
 	return out
+}
+
+func redactedJSONType(value any) string {
+	return fmt.Sprintf("<redacted %s>", jsonTypeName(value))
+}
+
+func jsonTypeName(value any) string {
+	switch value.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return "number"
+	case string:
+		return "string"
+	case []any:
+		return "array"
+	case map[string]any:
+		return "object"
+	default:
+		return fmt.Sprintf("%T", value)
+	}
 }
 
 // Summarizable is implemented by result types that want to produce their

--- a/internal/telemetry/sanitize_test.go
+++ b/internal/telemetry/sanitize_test.go
@@ -34,6 +34,33 @@ func TestSanitizeArgsStripsFactsAndObservationsArrays(t *testing.T) {
 	}
 }
 
+func TestSanitizeArgsRedactsInvalidSensitiveTypes(t *testing.T) {
+	sentinel := "SECRET-INVALID-PAYLOAD"
+	got := SanitizeArgs(map[string]any{
+		"entity":      map[string]any{"secret": sentinel},
+		"observation": map[string]any{"secret": sentinel},
+		"context":     []any{sentinel},
+		"facts":       map[string]any{"secret": sentinel},
+		"observations": map[string]any{
+			"secret": sentinel,
+		},
+	}, true)
+	if strings.Contains(got, sentinel) {
+		t.Fatalf("invalid sensitive payload leaked in args_summary: %s", got)
+	}
+	for _, marker := range []string{
+		`"entity":"<redacted object>"`,
+		`"observation":"<redacted object>"`,
+		`"context":"<redacted array>"`,
+		`"facts":"<redacted object>"`,
+		`"observations":"<redacted object>"`,
+	} {
+		if !strings.Contains(got, marker) {
+			t.Fatalf("missing redaction marker %s in args_summary: %s", marker, got)
+		}
+	}
+}
+
 func TestSanitizeArgsStrictModeHashesIdentifiers(t *testing.T) {
 	got := SanitizeArgs(map[string]any{
 		"entity": "Alice",


### PR DESCRIPTION
## Summary
- Redact malformed sensitive MCP arguments by key/type before telemetry logging.
- Stop validation errors from echoing raw invalid payloads back to clients.
- Add strict telemetry end-to-end regression coverage for malformed sensitive inputs.

## Testing
- go test ./...
- git diff --check