### PR TITLE
fix(store): validate confidence and relation inputs

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -27,7 +27,12 @@ The Go implementation should preserve the MCP tool surface unless there is a del
 ## Behavioral expectations
 
 - `remember` stores or reuses an entity and appends a fact.
+- `remember`, `remember_batch`, and `remember_event` accept `confidence`
+  only in the inclusive `0.0-1.0` range when provided; out-of-range,
+  NaN, or infinite values are validation errors and must not mutate the DB.
 - `recall` returns ranked grouped results with confidence and composite score semantics preserved as closely as practical.
+- `relate` creates directed relations between two distinct entities;
+  self-referencing relations are validation errors and must not mutate the DB.
 - `forget` soft-deletes observations or entities and must remove deleted observations from FTS recall.
 - `project`-scoped calls route to an isolated DB under the target project.
 - provenance tools bypass ranking and return direct facts by identifier, but they must not bypass lifecycle visibility guards such as tombstones or event expiry.

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -32,7 +32,9 @@ The Go implementation should preserve the MCP tool surface unless there is a del
   NaN, or infinite values are validation errors and must not mutate the DB.
 - `recall` returns ranked grouped results with confidence and composite score semantics preserved as closely as practical.
 - `relate` creates directed relations between two distinct entities;
-  self-referencing relations are validation errors and must not mutate the DB.
+  self-referencing relations are validation errors under the same
+  case-insensitive entity-name semantics used by entity lookup, and must not
+  mutate the DB.
 - `forget` soft-deletes observations or entities and must remove deleted observations from FTS recall.
 - `project`-scoped calls route to an isolated DB under the target project.
 - provenance tools bypass ranking and return direct facts by identifier, but they must not bypass lifecycle visibility guards such as tombstones or event expiry.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -18,7 +18,7 @@
 - Telemetry summaries and validation errors must never include raw sensitive payloads. This applies before type validation too: malformed `observation`, `content`, `context`, `facts`, or `observations` values are redacted by key and JSON type, not serialized as received.
 - New memory directories must be private by default (`0700`) and SQLite DB files plus SQLite sidecars (`-wal`, `-shm`, `-journal`) are best-effort hardened to `0600` on POSIX filesystems.
 - Tool-level write paths must reject confidence values outside the documented inclusive `0.0-1.0` range before any DB mutation.
-- `relate` must reject self-referencing relations before any DB mutation.
+- `relate` must reject self-referencing relations before any DB mutation, using the same case-insensitive entity-name semantics as entity lookup.
 - User input used in SQL `LIKE` predicates must escape `%`, `_`, and `\` and include an explicit `ESCAPE '\'` clause.
 
 ## Active Debt

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -17,6 +17,9 @@
 - When `MEMORY_TELEMETRY_PRIVACY=strict`, entity names, queries, and event labels must be sha256-hashed before reaching disk. Observation/content values are always reduced to `<N chars>` regardless of mode.
 - Telemetry summaries and validation errors must never include raw sensitive payloads. This applies before type validation too: malformed `observation`, `content`, `context`, `facts`, or `observations` values are redacted by key and JSON type, not serialized as received.
 - New memory directories must be private by default (`0700`) and SQLite DB files plus SQLite sidecars (`-wal`, `-shm`, `-journal`) are best-effort hardened to `0600` on POSIX filesystems.
+- Tool-level write paths must reject confidence values outside the documented inclusive `0.0-1.0` range before any DB mutation.
+- `relate` must reject self-referencing relations before any DB mutation.
+- User input used in SQL `LIKE` predicates must escape `%`, `_`, and `\` and include an explicit `ESCAPE '\'` clause.
 
 ## Active Debt
 
@@ -56,18 +59,6 @@ Blast radius: Search quality and conflict hints degrade without an operational s
 Fix: Surface FTS degradation through telemetry/metrics or a structured warning path without making normal recall fail when fallback channels are available.
 Done when: tests cover FTS query failure producing an observable degraded signal while preserving fallback search behavior.
 
-- Confidence values above `1.0` are accepted despite the MCP contract describing `0.0-1.0`.
-Trigger: A caller passes `confidence > 1.0` to `remember`, `remember_batch`, or `remember_event`.
-Blast radius: Stored confidence and derived `effective_confidence` exceed the intended range, inflating composite ranking and conflict scores.
-Fix: Reject or clamp out-of-range confidence consistently at the tool validation/store boundary; document the chosen behavior in `API_CONTRACT.md` if user-visible.
-Done when: tests cover negative, zero, in-range, and above-one confidence across single and batch/event write paths.
-
-- `relate` permits self-referencing relations.
-Trigger: A caller sends `relate(from: X, to: X, relation_type: R)`.
-Blast radius: Entity graphs can contain meaningless self-loops in both outgoing and incoming relations, confusing downstream consumers and review/debug output.
-Fix: Reject self-relations in validation; optionally add a SQLite `CHECK (from_entity_id != to_entity_id)` in the next migration path.
-Done when: a regression test proves self-relations are rejected before any DB mutation.
-
 - The Go port now replays the shared product fixtures locally, but still lacks an automated Node-vs-Go dual-runtime comparison in CI.
 Trigger: Trusting Go-only fixture replay as full parity proof.
 Blast radius: Drift from the JS reference can sneak in when both sides evolve independently.
@@ -101,12 +92,6 @@ Trigger: A long-running MCP server touches many distinct project paths over time
 Blast radius: The `projectDBs` map and open SQLite file descriptors grow until shutdown; small personal use is fine, broad workspace use can leak resources.
 Fix: Add a bounded cache with lazy close/eviction, or an explicit max cap with deterministic close behavior.
 Done when: a regression test opens more than the cap and proves older project DB handles are closed/evicted without breaking active global storage.
-
-- `SearchEvents` label wildcard escaping lacks direct regression coverage.
-Trigger: A future change edits `SearchEvents` or `escapeLikePattern` and breaks literal `%`, `_`, or `\` searches for event labels.
-Blast radius: The PR #14 event-label hardening can regress while the current event count test still passes because it uses an empty query.
-Fix: Add a `SearchEvents` test with labels containing LIKE wildcards and backslashes, proving literal matching excludes wildcard-expanded neighbors.
-Done when: the test fails if `ESCAPE '\'` or `escapeLikePattern(query)` is removed from the event-label path.
 
 - Schema migrations are still inline `ALTER TABLE` statements guarded by duplicate-schema string matching.
 Trigger: Adding more migrations before replacing the guard with explicit migration tracking.

--- a/internal/store/events_test.go
+++ b/internal/store/events_test.go
@@ -49,3 +49,52 @@ func TestSearchEventsCountsObservationsCorrectly(t *testing.T) {
 		t.Fatalf("SearchEvents() ObservationCount = %d, want 3", results[0].ObservationCount)
 	}
 }
+
+func TestSearchEventsEscapesLikeWildcards(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "events-like-escape.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	labels := []string{
+		"Launch 50% discount",
+		"Launch 500 discount",
+		"file_name rollout",
+		"file-name rollout",
+		`path\prod migration`,
+		"path/prod migration",
+	}
+	for _, label := range labels {
+		if _, err := CreateEvent(db, label, "2026-04-26", "test", "", ""); err != nil {
+			t.Fatalf("CreateEvent(%q) error = %v", label, err)
+		}
+	}
+
+	cases := []struct {
+		name      string
+		query     string
+		wantLabel string
+	}{
+		{name: "percent is literal", query: "50%", wantLabel: "Launch 50% discount"},
+		{name: "underscore is literal", query: "file_name", wantLabel: "file_name rollout"},
+		{name: "backslash is literal", query: `path\prod`, wantLabel: `path\prod migration`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			results, err := SearchEvents(db, tc.query, "", "", "", 10)
+			if err != nil {
+				t.Fatalf("SearchEvents(%q) error = %v", tc.query, err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("SearchEvents(%q) returned %d results, want exactly 1: %#v", tc.query, len(results), results)
+			}
+			if results[0].Label != tc.wantLabel {
+				t.Fatalf("SearchEvents(%q) label = %q, want %q", tc.query, results[0].Label, tc.wantLabel)
+			}
+		})
+	}
+}

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -253,8 +253,8 @@ func TestCoreMemoryParity(t *testing.T) {
 		}
 	})
 
-	t.Run("relate rejects self relation before mutation", func(t *testing.T) {
-		_, err := HandleTool(db, "relate", ToolArgs{From: "SelfRelationEntity", To: "SelfRelationEntity", RelationType: "same_as"})
+	t.Run("relate rejects case-insensitive self relation before mutation", func(t *testing.T) {
+		_, err := HandleTool(db, "relate", ToolArgs{From: "SelfRelationEntity", To: "selfrelationentity", RelationType: "same_as"})
 		if err == nil {
 			t.Fatal("HandleTool(relate self) error = nil, want validation error")
 		}

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -173,6 +173,110 @@ func TestCoreMemoryParity(t *testing.T) {
 			t.Fatalf("entityCount = %d, want 0 after rejected remember", entityCount)
 		}
 	})
+
+	t.Run("write tools reject confidence outside contract before mutation", func(t *testing.T) {
+		high := 1.01
+		negative := -0.01
+		cases := []struct {
+			name       string
+			tool       string
+			args       ToolArgs
+			entityName string
+			eventLabel string
+		}{
+			{
+				name:       "remember high confidence",
+				tool:       "remember",
+				args:       ToolArgs{Entity: "HighConfidenceRemember", Observation: "too confident", Confidence: &high},
+				entityName: "HighConfidenceRemember",
+			},
+			{
+				name:       "remember negative confidence",
+				tool:       "remember",
+				args:       ToolArgs{Entity: "NegativeConfidenceRemember", Observation: "negative confidence", Confidence: &negative},
+				entityName: "NegativeConfidenceRemember",
+			},
+			{
+				name:       "remember_batch high confidence",
+				tool:       "remember_batch",
+				args:       ToolArgs{Facts: []FactInput{{Entity: "HighConfidenceBatch", Observation: "too confident batch", Confidence: &high}}},
+				entityName: "HighConfidenceBatch",
+			},
+			{
+				name:       "remember_event high confidence",
+				tool:       "remember_event",
+				args:       ToolArgs{Label: "High confidence event", Observations: []FactInput{{Entity: "HighConfidenceEventEntity", Observation: "too confident event", Confidence: &high}}},
+				entityName: "HighConfidenceEventEntity",
+				eventLabel: "High confidence event",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := HandleTool(db, tc.tool, tc.args)
+				if err == nil {
+					t.Fatalf("HandleTool(%s) error = nil, want confidence validation error", tc.tool)
+				}
+				if !strings.Contains(err.Error(), "confidence must be between 0.0 and 1.0") {
+					t.Fatalf("HandleTool(%s) error = %q, want confidence range validation", tc.tool, err)
+				}
+
+				var entityCount int
+				if err := db.QueryRow(`SELECT COUNT(*) FROM entities WHERE name = ?`, tc.entityName).Scan(&entityCount); err != nil {
+					t.Fatalf("count entities after rejected %s error = %v", tc.tool, err)
+				}
+				if entityCount != 0 {
+					t.Fatalf("entityCount = %d, want 0 after rejected %s", entityCount, tc.tool)
+				}
+
+				if tc.eventLabel != "" {
+					var eventCount int
+					if err := db.QueryRow(`SELECT COUNT(*) FROM events WHERE label = ?`, tc.eventLabel).Scan(&eventCount); err != nil {
+						t.Fatalf("count events after rejected %s error = %v", tc.tool, err)
+					}
+					if eventCount != 0 {
+						t.Fatalf("eventCount = %d, want 0 after rejected %s", eventCount, tc.tool)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("write tools accept confidence bounds", func(t *testing.T) {
+		zero := 0.0
+		one := 1.0
+		if _, err := HandleTool(db, "remember", ToolArgs{Entity: "ZeroConfidenceEntity", Observation: "zero confidence is allowed", Confidence: &zero}); err != nil {
+			t.Fatalf("HandleTool(remember zero confidence) error = %v", err)
+		}
+		if _, err := HandleTool(db, "remember", ToolArgs{Entity: "OneConfidenceEntity", Observation: "one confidence is allowed", Confidence: &one}); err != nil {
+			t.Fatalf("HandleTool(remember one confidence) error = %v", err)
+		}
+	})
+
+	t.Run("relate rejects self relation before mutation", func(t *testing.T) {
+		_, err := HandleTool(db, "relate", ToolArgs{From: "SelfRelationEntity", To: "SelfRelationEntity", RelationType: "same_as"})
+		if err == nil {
+			t.Fatal("HandleTool(relate self) error = nil, want validation error")
+		}
+		if !strings.Contains(err.Error(), "from and to must be different") {
+			t.Fatalf("HandleTool(relate self) error = %q, want self-relation validation", err)
+		}
+
+		var entityCount int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM entities WHERE name = 'SelfRelationEntity'`).Scan(&entityCount); err != nil {
+			t.Fatalf("count entities after rejected self relate error = %v", err)
+		}
+		if entityCount != 0 {
+			t.Fatalf("entityCount = %d, want 0 after rejected self relate", entityCount)
+		}
+		var relationCount int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM relations WHERE relation_type = 'same_as'`).Scan(&relationCount); err != nil {
+			t.Fatalf("count relations after rejected self relate error = %v", err)
+		}
+		if relationCount != 0 {
+			t.Fatalf("relationCount = %d, want 0 after rejected self relate", relationCount)
+		}
+	})
 }
 
 func TestEventsAndProvenanceParity(t *testing.T) {

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -413,6 +414,9 @@ func validateToolArgs(name string, args ToolArgs) error {
 		if err := validateNonEmptyField("observation", args.Observation); err != nil {
 			return err
 		}
+		if err := validateConfidence("confidence", args.Confidence); err != nil {
+			return err
+		}
 	case "remember_batch":
 		for index, fact := range args.Facts {
 			if err := validateFactInput(fact, fmt.Sprintf("facts[%d]", index)); err != nil {
@@ -433,6 +437,9 @@ func validateToolArgs(name string, args ToolArgs) error {
 		if err := validateNonEmptyField("relation_type", args.RelationType); err != nil {
 			return err
 		}
+		if strings.TrimSpace(args.From) == strings.TrimSpace(args.To) {
+			return fmt.Errorf("from and to must be different")
+		}
 	case "remember_event":
 		if err := validateNonEmptyField("label", args.Label); err != nil {
 			return err
@@ -452,6 +459,19 @@ func validateFactInput(fact FactInput, path string) error {
 	}
 	if err := validateNonEmptyField(path+".observation", fact.Observation); err != nil {
 		return err
+	}
+	if err := validateConfidence(path+".confidence", fact.Confidence); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateConfidence(fieldName string, value *float64) error {
+	if value == nil {
+		return nil
+	}
+	if math.IsNaN(*value) || math.IsInf(*value, 0) || *value < 0 || *value > 1 {
+		return fmt.Errorf("%s must be between 0.0 and 1.0", fieldName)
 	}
 	return nil
 }

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -437,7 +437,7 @@ func validateToolArgs(name string, args ToolArgs) error {
 		if err := validateNonEmptyField("relation_type", args.RelationType); err != nil {
 			return err
 		}
-		if strings.TrimSpace(args.From) == strings.TrimSpace(args.To) {
+		if strings.EqualFold(strings.TrimSpace(args.From), strings.TrimSpace(args.To)) {
 			return fmt.Errorf("from and to must be different")
 		}
 	case "remember_event":


### PR DESCRIPTION
## Summary
- Reject out-of-range confidence values on write tool paths before DB mutation.
- Reject self-referencing `relate` calls before creating entities or relations.
- Add direct `SearchEvents` wildcard escaping regression coverage and update public contract/operations docs.

## Testing
- go test ./...
- git diff --check