### PR TITLE
fix(store): make remember and relate atomic

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -20,6 +20,8 @@
 - Tool-level write paths must reject confidence values outside the documented inclusive `0.0-1.0` range before any DB mutation.
 - `relate` must reject self-referencing relations before any DB mutation, using the same case-insensitive entity-name semantics as entity lookup.
 - User input used in SQL `LIKE` predicates must escape `%`, `_`, and `\` and include an explicit `ESCAPE '\'` clause.
+- `remember` must commit `UpsertEntity`, conflict detection, and `AddObservation` atomically. If observation insert fails after entity upsert, neither entity nor observation may survive. Conflict detection still runs before inserting the new observation.
+- `relate` must commit endpoint entity upserts and relation insert atomically. If relation insertion fails for a non-idempotent reason, newly created endpoint entities must roll back; duplicate relations remain idempotent and return "Relation already exists".
 
 ## Active Debt
 
@@ -40,18 +42,6 @@ Fix (calibration protocol):
   5. After adjustment, reset the sample window and re-measure.
   6. Split telemetry by `tool_calls.db_scope` before computing the ratio. Global memory uses `MEMORY_HALF_LIFE_WEEKS` (12 by default) and project memory uses `PROJECT_MEMORY_HALF_LIFE_WEEKS` (52 by default), so observations of the same age decay differently across scopes and produce systematically different composite scores. Mixing both scopes into one ratio averages two distributions and pins a threshold that fits neither. The schema already exposes `db_scope`; the obligation is on the analysis path. Same goes for any future per-instance half-life override.
 Done when: either the threshold has been confirmed twice in a row at the same value with the ratio inside [0.5, 0.9], or telemetry has shown a clear reason to redesign the hint (e.g., lexical detection consistently misses semantic conflicts and a pure-Go embedding path becomes available).
-
-- `remember` conflict detection and observation insert are not wrapped in one transaction.
-Trigger: A future write path relies on conflict hints as an atomic statement about the exact state being committed, or `MaxOpenConns(1)` changes.
-Blast radius: Conflict hints can be computed against a state that is not the final committed write state; future concurrency changes could turn this from benign sequencing into stale hints.
-Fix: Wrap `UpsertEntity`, `DetectEntityConflicts`, and `AddObservation` for a single `remember` call in one transaction, preserving the current "detect before insert" self-match invariant.
-Done when: a regression test proves the transactional path still returns pre-insert conflicts and commits/rolls back as a unit.
-
-- `relate` can leave newly upserted entities behind if relation insertion fails after entity creation.
-Trigger: A non-unique relation insert or future validation/constraint failure happens after one or both endpoint entities were created for the call.
-Blast radius: Failed relation calls can leave orphan-ish entity rows that look intentional to future recall/list surfaces.
-Fix: Wrap both endpoint `UpsertEntity` calls and the relation insert in one transaction; preserve the existing "already exists" response for unique conflicts.
-Done when: a regression test forces relation insert failure and proves no new endpoint entities survive unless the relation is created or already existed.
 
 - FTS channel query errors in recall/conflict candidate collection are silently swallowed and degrade to non-FTS channels.
 Trigger: FTS table corruption, query syntax drift, driver behavior change, or migration bug breaks FTS while LIKE/entity channels still return results.

--- a/internal/store/conflict.go
+++ b/internal/store/conflict.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"database/sql"
 	"fmt"
 	"strings"
 )
@@ -50,7 +49,7 @@ const conflictHintMaxResults = 3
 //
 // Callers should invoke this BEFORE inserting the new observation so that
 // self-match filtering is unnecessary.
-func DetectEntityConflicts(db *sql.DB, entityID int64, content string, halfLifeWeeks float64) ([]ConflictHint, error) {
+func DetectEntityConflicts(db dbtx, entityID int64, content string, halfLifeWeeks float64) ([]ConflictHint, error) {
 	trimmed := strings.TrimSpace(content)
 	if entityID <= 0 || trimmed == "" {
 		return nil, nil
@@ -99,7 +98,7 @@ func DetectEntityConflicts(db *sql.DB, entityID int64, content string, halfLifeW
 // CollectCandidates in search.go but with a tighter scope and fewer
 // channels — entity-identity and event-based channels are skipped as
 // they are constant or irrelevant inside a single entity.
-func collectEntityScopedCandidates(db *sql.DB, entityID int64, content string) (map[int64]*candidate, error) {
+func collectEntityScopedCandidates(db dbtx, entityID int64, content string) (map[int64]*candidate, error) {
 	candidates := map[int64]*candidate{}
 	const (
 		maxCandidates = 50

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -838,6 +838,133 @@ func TestRememberEventAtomicityOnMidLoopFailure(t *testing.T) {
 	}
 }
 
+func TestRememberAtomicityOnObservationFailure(t *testing.T) {
+	db := newTestDB(t, "remember-atomicity.db")
+
+	if _, err := db.Exec(
+		`CREATE TRIGGER fail_remember_observation BEFORE INSERT ON observations
+		 WHEN NEW.content = 'remember tx fail'
+		 BEGIN SELECT RAISE(ABORT, 'injected observation failure'); END;`,
+	); err != nil {
+		t.Fatalf("install trigger: %v", err)
+	}
+
+	_, err := HandleTool(db, "remember", ToolArgs{Entity: "RememberTxEntity", Observation: "remember tx fail"})
+	if err == nil {
+		t.Fatalf("HandleTool(remember) expected error from injected failure, got nil")
+	}
+
+	var entityCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM entities WHERE name = ?`, "RememberTxEntity").Scan(&entityCount); err != nil {
+		t.Fatalf("count entity after failed remember: %v", err)
+	}
+	if entityCount != 0 {
+		t.Fatalf("remember entity persisted despite rollback: count=%d", entityCount)
+	}
+
+	var observationCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM observations WHERE content = ?`, "remember tx fail").Scan(&observationCount); err != nil {
+		t.Fatalf("count observations after failed remember: %v", err)
+	}
+	if observationCount != 0 {
+		t.Fatalf("remember observation persisted despite rollback: count=%d", observationCount)
+	}
+}
+
+func TestRememberAtomicityOnFTSFailure(t *testing.T) {
+	db := newTestDB(t, "remember-fts-atomicity.db")
+
+	// Force AddObservation to fail after inserting the observation row but
+	// before returning: the memory_fts insert is the final write in that helper.
+	if _, err := db.Exec(`DROP TABLE memory_fts`); err != nil {
+		t.Fatalf("drop memory_fts: %v", err)
+	}
+
+	_, err := HandleTool(db, "remember", ToolArgs{Entity: "RememberFTSFailureEntity", Observation: "fts failure should roll back"})
+	if err == nil {
+		t.Fatalf("HandleTool(remember) expected FTS failure, got nil")
+	}
+
+	var entityCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM entities WHERE name = ?`, "RememberFTSFailureEntity").Scan(&entityCount); err != nil {
+		t.Fatalf("count entity after FTS failure: %v", err)
+	}
+	if entityCount != 0 {
+		t.Fatalf("remember entity persisted despite FTS rollback: count=%d", entityCount)
+	}
+
+	var observationCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM observations WHERE content = ?`, "fts failure should roll back").Scan(&observationCount); err != nil {
+		t.Fatalf("count observations after FTS failure: %v", err)
+	}
+	if observationCount != 0 {
+		t.Fatalf("remember observation persisted despite FTS rollback: count=%d", observationCount)
+	}
+}
+
+func TestRelateAtomicityOnRelationFailure(t *testing.T) {
+	db := newTestDB(t, "relate-atomicity.db")
+
+	if _, err := db.Exec(
+		`CREATE TRIGGER fail_relation_insert BEFORE INSERT ON relations
+		 WHEN NEW.relation_type = 'fails'
+		 BEGIN SELECT RAISE(ABORT, 'injected relation failure'); END;`,
+	); err != nil {
+		t.Fatalf("install trigger: %v", err)
+	}
+
+	_, err := HandleTool(db, "relate", ToolArgs{From: "RollbackFrom", To: "RollbackTo", RelationType: "fails"})
+	if err == nil {
+		t.Fatalf("HandleTool(relate) expected error from injected failure, got nil")
+	}
+
+	var entityCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM entities WHERE name IN (?, ?)`, "RollbackFrom", "RollbackTo").Scan(&entityCount); err != nil {
+		t.Fatalf("count entities after failed relate: %v", err)
+	}
+	if entityCount != 0 {
+		t.Fatalf("relate endpoint entities persisted despite rollback: count=%d", entityCount)
+	}
+
+	var relationCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM relations WHERE relation_type = ?`, "fails").Scan(&relationCount); err != nil {
+		t.Fatalf("count relations after failed relate: %v", err)
+	}
+	if relationCount != 0 {
+		t.Fatalf("relation persisted despite rollback: count=%d", relationCount)
+	}
+}
+
+func TestRelateExistingRelationRemainsIdempotent(t *testing.T) {
+	db := newTestDB(t, "relate-idempotent.db")
+
+	firstAny, err := HandleTool(db, "relate", ToolArgs{From: "ExistingFrom", To: "ExistingTo", RelationType: "depends_on"})
+	if err != nil {
+		t.Fatalf("HandleTool(relate first) error = %v", err)
+	}
+	first := firstAny.(RelateResult)
+	if !first.Created {
+		t.Fatalf("first relate Created = false, want true: %#v", first)
+	}
+
+	secondAny, err := HandleTool(db, "relate", ToolArgs{From: "ExistingFrom", To: "ExistingTo", RelationType: "depends_on"})
+	if err != nil {
+		t.Fatalf("HandleTool(relate duplicate) error = %v", err)
+	}
+	second := secondAny.(RelateResult)
+	if second.Created || second.Message != "Relation already exists" {
+		t.Fatalf("duplicate relate result = %#v, want Created=false already-exists message", second)
+	}
+
+	var relationCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM relations WHERE relation_type = ?`, "depends_on").Scan(&relationCount); err != nil {
+		t.Fatalf("count duplicate relation rows: %v", err)
+	}
+	if relationCount != 1 {
+		t.Fatalf("relationCount = %d, want 1 after duplicate relate", relationCount)
+	}
+}
+
 // SearchMetrics.Query must match the trimmed query actually executed against
 // the index — otherwise two recall calls that only differ by leading or
 // trailing whitespace look like distinct queries in telemetry even though

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -250,7 +250,7 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 	return candidates, nil
 }
 
-func HydrateCandidates(db *sql.DB, candidateMap map[int64]*candidate) ([]SearchObservation, error) {
+func HydrateCandidates(db dbtx, candidateMap map[int64]*candidate) ([]SearchObservation, error) {
 	if len(candidateMap) == 0 {
 		return nil, nil
 	}
@@ -535,7 +535,7 @@ func collectFTSRows(rows *sql.Rows, candidateMap map[int64]*candidate, channel s
 	return rows.Err()
 }
 
-func collectSimpleIDs(db *sql.DB, candidateMap map[int64]*candidate, maxCandidates int, channel string, query string, args ...any) error {
+func collectSimpleIDs(db dbtx, candidateMap map[int64]*candidate, maxCandidates int, channel string, query string, args ...any) error {
 	rows, err := db.Query(query, args...)
 	if err != nil {
 		return fmt.Errorf("collect %s ids: %w", channel, err)

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -162,23 +162,34 @@ func dispatchTool(defaultDB *sql.DB, name string, args ToolArgs, outMetrics **Se
 
 	switch name {
 	case "remember":
-		entityID, err := UpsertEntity(db, args.Entity, args.EntityType)
+		tx, err := db.Begin()
+		if err != nil {
+			return nil, fmt.Errorf("begin remember: %w", err)
+		}
+		defer tx.Rollback()
+		entityID, err := UpsertEntity(tx, args.Entity, args.EntityType)
 		if err != nil {
 			return nil, err
 		}
 		// Detect conflicts BEFORE insert so the detector scans an
 		// already-consistent state and self-match filtering is
-		// unnecessary. See DECISION_LOG 2026-04-22. Pass the
+		// unnecessary. The detector must use the same transaction: using
+		// the parent *sql.DB here can deadlock under SetMaxOpenConns(1)
+		// and would no longer observe the exact state being committed.
+		// See DECISION_LOG 2026-04-22. Pass the
 		// scope-aware halfLife computed above so project memory uses
 		// its own (longer) decay rate when scoring potential conflicts
 		// — see Kimi general-review finding (PR #11 follow-up).
-		conflicts, err := DetectEntityConflicts(db, entityID, args.Observation, halfLife)
+		conflicts, err := DetectEntityConflicts(tx, entityID, args.Observation, halfLife)
 		if err != nil {
 			return nil, err
 		}
-		observationID, err := AddObservation(db, entityID, args.Observation, defaultSource(args.Source), defaultConfidence(args.Confidence), optionalEventID(args.EventID)...)
+		observationID, err := AddObservation(tx, entityID, args.Observation, defaultSource(args.Source), defaultConfidence(args.Confidence), optionalEventID(args.EventID)...)
 		if err != nil {
 			return nil, err
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit remember: %w", err)
 		}
 		return RememberResult{Stored: true, EntityID: entityID, ObservationID: observationID, EventID: args.EventID, Project: stringPointer(args.Project), PossibleConflicts: conflicts}, nil
 
@@ -243,20 +254,34 @@ func dispatchTool(defaultDB *sql.DB, name string, args ToolArgs, outMetrics **Se
 		return RecallEntityResult{Found: true, Entity: graph.Entity, Observations: graph.Observations, RelationsOutgoing: graph.RelationsOutgoing, RelationsIncoming: graph.RelationsIncoming}, nil
 
 	case "relate":
-		fromID, err := UpsertEntity(db, args.From, "")
+		tx, err := db.Begin()
+		if err != nil {
+			return nil, fmt.Errorf("begin relate: %w", err)
+		}
+		defer tx.Rollback()
+		fromID, err := UpsertEntity(tx, args.From, "")
 		if err != nil {
 			return nil, err
 		}
-		toID, err := UpsertEntity(db, args.To, "")
+		toID, err := UpsertEntity(tx, args.To, "")
 		if err != nil {
 			return nil, err
 		}
-		_, err = db.Exec(`INSERT INTO relations (from_entity_id, to_entity_id, relation_type, context) VALUES (?, ?, ?, ?)`, fromID, toID, args.RelationType, nullableString(args.Context, ""))
+		_, err = tx.Exec(`INSERT INTO relations (from_entity_id, to_entity_id, relation_type, context) VALUES (?, ?, ?, ?)`, fromID, toID, args.RelationType, nullableString(args.Context, ""))
 		if err != nil {
 			if strings.Contains(strings.ToLower(err.Error()), "unique") {
+				// Preserve the pre-transaction idempotent behavior: endpoint
+				// upserts have already succeeded, and a UNIQUE relation error
+				// means this exact relation row already exists for those IDs.
+				if err := tx.Commit(); err != nil {
+					return nil, fmt.Errorf("commit existing relation: %w", err)
+				}
 				return RelateResult{Created: false, Message: "Relation already exists"}, nil
 			}
 			return nil, fmt.Errorf("insert relation: %w", err)
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit relate: %w", err)
 		}
 		return RelateResult{Created: true, From: args.From, To: args.To, RelationType: args.RelationType}, nil
 


### PR DESCRIPTION
## Summary
- Wrap `remember` entity upsert, conflict detection, and observation insert in one transaction.
- Wrap `relate` endpoint upserts and relation insert in one transaction while preserving duplicate relation idempotency.
- Add rollback regression tests for observation insert failure, FTS insert failure, and relation insert failure.

## Review
- GLM correctness review on uncommitted changes found no blockers.
- Follow-up added direct FTS rollback coverage and comments for transaction visibility/idempotent relation behavior.

## Testing
- go test ./...
- git diff --check