### PR TITLE
fix(telemetry): report fts degradation

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -22,6 +22,7 @@
 - User input used in SQL `LIKE` predicates must escape `%`, `_`, and `\` and include an explicit `ESCAPE '\'` clause.
 - `remember` must commit `UpsertEntity`, conflict detection, and `AddObservation` atomically. If observation insert fails after entity upsert, neither entity nor observation may survive. Conflict detection still runs before inserting the new observation.
 - `relate` must commit endpoint entity upserts and relation insert atomically. If relation insertion fails for a non-idempotent reason, newly created endpoint entities must roll back; duplicate relations remain idempotent and return "Relation already exists".
+- FTS `MATCH` query failures in search/conflict candidate collection are non-fatal only when fallback channels can continue, and must emit a degraded signal: `search_metrics.fts_query_errors` for recall, `tool_calls.conflict_fts_query_errors` for remember conflict detection.
 
 ## Active Debt
 
@@ -42,12 +43,6 @@ Fix (calibration protocol):
   5. After adjustment, reset the sample window and re-measure.
   6. Split telemetry by `tool_calls.db_scope` before computing the ratio. Global memory uses `MEMORY_HALF_LIFE_WEEKS` (12 by default) and project memory uses `PROJECT_MEMORY_HALF_LIFE_WEEKS` (52 by default), so observations of the same age decay differently across scopes and produce systematically different composite scores. Mixing both scopes into one ratio averages two distributions and pins a threshold that fits neither. The schema already exposes `db_scope`; the obligation is on the analysis path. Same goes for any future per-instance half-life override.
 Done when: either the threshold has been confirmed twice in a row at the same value with the ratio inside [0.5, 0.9], or telemetry has shown a clear reason to redesign the hint (e.g., lexical detection consistently misses semantic conflicts and a pure-Go embedding path becomes available).
-
-- FTS channel query errors in recall/conflict candidate collection are silently swallowed and degrade to non-FTS channels.
-Trigger: FTS table corruption, query syntax drift, driver behavior change, or migration bug breaks FTS while LIKE/entity channels still return results.
-Blast radius: Search quality and conflict hints degrade without an operational signal; telemetry calibration can misread an FTS outage as threshold or model behavior.
-Fix: Surface FTS degradation through telemetry/metrics or a structured warning path without making normal recall fail when fallback channels are available.
-Done when: tests cover FTS query failure producing an observable degraded signal while preserving fallback search behavior.
 
 - The Go port now replays the shared product fixtures locally, but still lacks an automated Node-vs-Go dual-runtime comparison in CI.
 Trigger: Trusting Go-only fixture replay as full parity proof.

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -64,6 +64,8 @@ Every MCP tool invocation is logged with:
 | `args_summary` | Sanitized JSON (see below) |
 | `result_summary` | Counts only, never data |
 | `is_error` | `0` or `1` |
+| `conflicts_surfaced` | Number of `remember` conflict hints returned |
+| `conflict_fts_query_errors` | Non-fatal FTS query failures during `remember` conflict detection |
 
 ### Search ranking metrics (`search_metrics` table)
 
@@ -80,6 +82,7 @@ For `recall` calls, additional metrics capture the ranking pipeline:
 | `score_min` | `0.32` |
 | `score_max` | `0.87` |
 | `score_median` | `0.61` |
+| `fts_query_errors` | Non-fatal FTS query failures before fallback channels completed |
 | `compact` | `0` or `1` |
 
 ## What it does NOT log
@@ -125,10 +128,29 @@ ORDER BY calls DESC;
 ```sql
 SELECT query, candidates_total, results_returned,
        ROUND(score_min, 3) as min, ROUND(score_max, 3) as max,
-       channels
+       fts_query_errors, channels
 FROM search_metrics
 ORDER BY candidates_total DESC
 LIMIT 20;
+```
+
+**FTS degradation detection:**
+```sql
+SELECT tc.ts, tc.tool, sm.query, sm.fts_query_errors, sm.channels
+FROM search_metrics sm
+JOIN tool_calls tc ON tc.id = sm.tool_call_id
+WHERE sm.fts_query_errors > 0
+ORDER BY tc.ts DESC;
+```
+
+For `remember` conflict hints, non-fatal FTS degradation is recorded on the
+parent tool call:
+
+```sql
+SELECT ts, tool, conflicts_surfaced, conflict_fts_query_errors
+FROM tool_calls
+WHERE conflict_fts_query_errors > 0
+ORDER BY ts DESC;
 ```
 
 **Overfetch detection (candidates >> returned):**

--- a/internal/mcpserver/telemetry.go
+++ b/internal/mcpserver/telemetry.go
@@ -67,15 +67,16 @@ func (r *Runtime) logToolCall(
 		projectPath = resolveProjectPath(projectRaw)
 	}
 	return tele.LogToolCall(telemetry.ToolCallInput{
-		Tool:              toolName,
-		Client:            detectClient(req),
-		DBScope:           dbScope,
-		ProjectPath:       projectPath,
-		DurationMs:        float64(elapsed) / float64(time.Millisecond),
-		ArgsSummary:       telemetry.SanitizeArgs(argObject, tele.Strict()),
-		ResultSummary:     telemetry.SummarizeResult(result),
-		IsError:           isError,
-		ConflictsSurfaced: conflictsSurfacedCount(result),
+		Tool:                   toolName,
+		Client:                 detectClient(req),
+		DBScope:                dbScope,
+		ProjectPath:            projectPath,
+		DurationMs:             float64(elapsed) / float64(time.Millisecond),
+		ArgsSummary:            telemetry.SanitizeArgs(argObject, tele.Strict()),
+		ResultSummary:          telemetry.SummarizeResult(result),
+		IsError:                isError,
+		ConflictsSurfaced:      conflictsSurfacedCount(result),
+		ConflictFTSQueryErrors: conflictFTSQueryErrors(result),
 	})
 }
 
@@ -90,6 +91,14 @@ func conflictsSurfacedCount(result any) int {
 		return 0
 	}
 	return len(remember.PossibleConflicts)
+}
+
+func conflictFTSQueryErrors(result any) int {
+	remember, ok := result.(store.RememberResult)
+	if !ok {
+		return 0
+	}
+	return remember.ConflictFTSQueryErrors
 }
 
 // logSearchMetrics mirrors the recall search_metrics row. No-op when the
@@ -109,6 +118,7 @@ func (r *Runtime) logSearchMetrics(tele *telemetry.Client, toolCallID int64, m *
 		ScoreMin:        m.ScoreMin,
 		ScoreMax:        m.ScoreMax,
 		ScoreMedian:     m.ScoreMedian,
+		FTSQueryErrors:  m.FTSQueryErrors,
 		Compact:         m.Compact,
 	})
 }

--- a/internal/mcpserver/telemetry_integration_test.go
+++ b/internal/mcpserver/telemetry_integration_test.go
@@ -107,8 +107,8 @@ func TestTelemetryEnabledRoundtripLogsToolCallsAndSearchMetrics(t *testing.T) {
 	}
 
 	var smQuery sql.NullString
-	var candidatesTotal, resultsReturned int
-	if err := rdb.QueryRow(`SELECT query, candidates_total, results_returned FROM search_metrics`).Scan(&smQuery, &candidatesTotal, &resultsReturned); err != nil {
+	var candidatesTotal, resultsReturned, ftsQueryErrors int
+	if err := rdb.QueryRow(`SELECT query, candidates_total, results_returned, fts_query_errors FROM search_metrics`).Scan(&smQuery, &candidatesTotal, &resultsReturned, &ftsQueryErrors); err != nil {
 		t.Fatalf("readback search_metrics: %v", err)
 	}
 	if smQuery.String != "TelemetryEntity" {
@@ -116,6 +116,9 @@ func TestTelemetryEnabledRoundtripLogsToolCallsAndSearchMetrics(t *testing.T) {
 	}
 	if candidatesTotal == 0 {
 		t.Fatalf("search_metrics.candidates_total = 0, want > 0")
+	}
+	if ftsQueryErrors != 0 {
+		t.Fatalf("search_metrics.fts_query_errors = %d, want 0 on healthy FTS", ftsQueryErrors)
 	}
 }
 

--- a/internal/store/conflict.go
+++ b/internal/store/conflict.go
@@ -50,25 +50,30 @@ const conflictHintMaxResults = 3
 // Callers should invoke this BEFORE inserting the new observation so that
 // self-match filtering is unnecessary.
 func DetectEntityConflicts(db dbtx, entityID int64, content string, halfLifeWeeks float64) ([]ConflictHint, error) {
+	hints, _, err := DetectEntityConflictsWithDiagnostics(db, entityID, content, halfLifeWeeks)
+	return hints, err
+}
+
+func DetectEntityConflictsWithDiagnostics(db dbtx, entityID int64, content string, halfLifeWeeks float64) ([]ConflictHint, int, error) {
 	trimmed := strings.TrimSpace(content)
 	if entityID <= 0 || trimmed == "" {
-		return nil, nil
+		return nil, 0, nil
 	}
 
-	candidates, err := collectEntityScopedCandidates(db, entityID, trimmed)
+	candidates, diagnostics, err := collectEntityScopedCandidatesWithDiagnostics(db, entityID, trimmed)
 	if err != nil {
-		return nil, err
+		return nil, diagnostics.FTSQueryErrors, err
 	}
 	if len(candidates) == 0 {
-		return nil, nil
+		return nil, diagnostics.FTSQueryErrors, nil
 	}
 
 	hydrated, err := HydrateCandidates(db, candidates)
 	if err != nil {
-		return nil, err
+		return nil, diagnostics.FTSQueryErrors, err
 	}
 	if len(hydrated) == 0 {
-		return nil, nil
+		return nil, diagnostics.FTSQueryErrors, nil
 	}
 
 	// Preserve every candidate through scoring so we can threshold-filter
@@ -90,7 +95,7 @@ func DetectEntityConflicts(db dbtx, entityID int64, content string, halfLifeWeek
 			break
 		}
 	}
-	return hints, nil
+	return hints, diagnostics.FTSQueryErrors, nil
 }
 
 // collectEntityScopedCandidates runs fts_phrase, fts, and content_like
@@ -99,7 +104,13 @@ func DetectEntityConflicts(db dbtx, entityID int64, content string, halfLifeWeek
 // channels — entity-identity and event-based channels are skipped as
 // they are constant or irrelevant inside a single entity.
 func collectEntityScopedCandidates(db dbtx, entityID int64, content string) (map[int64]*candidate, error) {
+	candidates, _, err := collectEntityScopedCandidatesWithDiagnostics(db, entityID, content)
+	return candidates, err
+}
+
+func collectEntityScopedCandidatesWithDiagnostics(db dbtx, entityID int64, content string) (map[int64]*candidate, collectionDiagnostics, error) {
 	candidates := map[int64]*candidate{}
+	diagnostics := collectionDiagnostics{}
 	const (
 		maxCandidates = 50
 		collectLimit  = 20
@@ -108,16 +119,13 @@ func collectEntityScopedCandidates(db dbtx, entityID int64, content string) (map
 	terms := strings.Fields(content)
 	cleanTerms := stripQuotes(terms)
 	if len(cleanTerms) == 0 {
-		return candidates, nil
+		return candidates, diagnostics, nil
 	}
 
-	// FTS error handling note: both FTS channels silence Query errors via
-	// `if err == nil`, mirroring the pattern in search.go so conflict
-	// detection degrades the same way recall does when the FTS layer is
-	// unavailable. The calibration consequence is that an FTS outage shows
-	// up in telemetry as a run of `conflicts_surfaced = 0` rather than as
-	// errors — review the surface-to-act ratio in light of any known FTS
-	// incident before pinning thresholds from that period.
+	// FTS query errors are non-fatal here: conflict detection degrades to the
+	// content_like fallback channel, and diagnostics preserve an observable
+	// signal for remember telemetry (`conflict_fts_query_errors`). Row scan or
+	// iteration errors after a successful query still return hard errors.
 
 	// fts_phrase — full phrase, only meaningful with multiple terms.
 	if len(cleanTerms) > 1 {
@@ -132,8 +140,10 @@ func collectEntityScopedCandidates(db dbtx, entityID int64, content string) (map
 		`, activeObservationSQL("o")), phraseQuery, entityID, collectLimit)
 		if err == nil {
 			if err := collectFTSRows(rows, candidates, "fts_phrase", maxCandidates); err != nil {
-				return nil, err
+				return nil, diagnostics, err
 			}
+		} else {
+			diagnostics.FTSQueryErrors++
 		}
 	}
 
@@ -150,8 +160,10 @@ func collectEntityScopedCandidates(db dbtx, entityID int64, content string) (map
 		`, activeObservationSQL("o")), ftsQuery, entityID, collectLimit)
 		if err == nil {
 			if err := collectFTSRows(rows, candidates, "fts", maxCandidates); err != nil {
-				return nil, err
+				return nil, diagnostics, err
 			}
+		} else {
+			diagnostics.FTSQueryErrors++
 		}
 	}
 
@@ -167,9 +179,9 @@ func collectEntityScopedCandidates(db dbtx, entityID int64, content string) (map
 			WHERE o.entity_id = ? AND %s AND e.deleted_at IS NULL AND o.content LIKE ? ESCAPE '\'
 			ORDER BY o.id LIMIT ?
 		`, activeObservationSQL("o")), entityID, "%"+escapeLikePattern(term)+"%", collectLimit); err != nil {
-			return nil, err
+			return nil, diagnostics, err
 		}
 	}
 
-	return candidates, nil
+	return candidates, diagnostics, nil
 }

--- a/internal/store/conflict_test.go
+++ b/internal/store/conflict_test.go
@@ -300,6 +300,37 @@ func TestHandleTool_RememberOmitsConflictsFieldWhenNoneQualify(t *testing.T) {
 	}
 }
 
+func TestDetectEntityConflictsReportsFTSQueryErrorsAndUsesFallback(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityID, err := UpsertEntity(db, "API", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	seedID, err := AddObservation(db, entityID, "rate limit is 100 per minute", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation: %v", err)
+	}
+	if _, err := db.Exec(`DROP TABLE memory_fts`); err != nil {
+		t.Fatalf("drop memory_fts: %v", err)
+	}
+
+	hints, ftsQueryErrors, err := DetectEntityConflictsWithDiagnostics(db, entityID, "rate limit is 200 per minute", memoryHalfLifeWeeks())
+	if err != nil {
+		t.Fatalf("DetectEntityConflictsWithDiagnostics: %v", err)
+	}
+	if ftsQueryErrors == 0 {
+		t.Fatalf("FTS query errors = 0, want degraded signal")
+	}
+	if len(hints) == 0 {
+		t.Fatalf("expected content_like fallback conflict hint despite FTS outage")
+	}
+	if hints[0].ObservationID != seedID {
+		t.Fatalf("hint observation_id = %d, want seed %d", hints[0].ObservationID, seedID)
+	}
+}
+
 // TestDetectEntityConflicts_HalfLifeParameterAffectsThreshold is the
 // regression fence for the bug Kimi's general-focus review caught after
 // PR #11 merged: DetectEntityConflicts had been hardcoding

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -29,6 +29,10 @@ type candidate struct {
 	FTSPosition       *int
 }
 
+type collectionDiagnostics struct {
+	FTSQueryErrors int
+}
+
 // SearchMetrics captures per-call ranking-pipeline observations, suitable for
 // telemetry. SearchMemory populates every field except Compact (which depends
 // on tool args and is set by the caller).
@@ -41,6 +45,7 @@ type SearchMetrics struct {
 	ScoreMin        float64
 	ScoreMax        float64
 	ScoreMedian     float64
+	FTSQueryErrors  int
 	Compact         bool
 }
 
@@ -141,12 +146,21 @@ func SanitizeSearchLimit(limit int) int {
 }
 
 func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int) (map[int64]*candidate, error) {
+	// Preserve the legacy low-level helper contract for tests/callers that only
+	// need candidates. SearchMemory uses collectCandidatesWithDiagnostics so FTS
+	// query degradation remains observable in recall telemetry.
+	candidates, _, err := collectCandidatesWithDiagnostics(db, query, collectLimit, maxCandidates)
+	return candidates, err
+}
+
+func collectCandidatesWithDiagnostics(db dbtx, query string, collectLimit, maxCandidates int) (map[int64]*candidate, collectionDiagnostics, error) {
 	trimmed := strings.TrimSpace(query)
 	if trimmed == "" {
-		return map[int64]*candidate{}, nil
+		return map[int64]*candidate{}, collectionDiagnostics{}, nil
 	}
 
 	candidates := map[int64]*candidate{}
+	diagnostics := collectionDiagnostics{}
 	terms := strings.Fields(trimmed)
 
 	if len(terms) > 1 {
@@ -161,8 +175,10 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 		`, activeObservationSQL("o")), phraseQuery, collectLimit)
 		if err == nil {
 			if err := collectFTSRows(rows, candidates, "fts_phrase", maxCandidates); err != nil {
-				return nil, err
+				return nil, diagnostics, err
 			}
+		} else {
+			diagnostics.FTSQueryErrors++
 		}
 	}
 
@@ -178,8 +194,10 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 		`, activeObservationSQL("o")), ftsQuery, collectLimit)
 		if err == nil {
 			if err := collectFTSRows(rows, candidates, "fts", maxCandidates); err != nil {
-				return nil, err
+				return nil, diagnostics, err
 			}
+		} else {
+			diagnostics.FTSQueryErrors++
 		}
 	}
 
@@ -189,7 +207,7 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 		WHERE %s AND e.deleted_at IS NULL AND e.name = ? COLLATE NOCASE
 		ORDER BY o.id LIMIT ?
 	`, activeObservationSQL("o")), trimmed, collectLimit); err != nil {
-		return nil, err
+		return nil, diagnostics, err
 	}
 
 	if len(candidates) < maxCandidates {
@@ -199,7 +217,7 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 			WHERE %s AND e.deleted_at IS NULL AND e.name LIKE ? ESCAPE '\' AND e.name != ? COLLATE NOCASE
 			ORDER BY o.id LIMIT ?
 		`, activeObservationSQL("o")), "%"+escapeLikePattern(trimmed)+"%", trimmed, collectLimit); err != nil {
-			return nil, err
+			return nil, diagnostics, err
 		}
 	}
 
@@ -214,7 +232,7 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 				WHERE %s AND e.deleted_at IS NULL AND o.content LIKE ? ESCAPE '\'
 				ORDER BY o.id LIMIT ?
 			`, activeObservationSQL("o")), "%"+escapeLikePattern(term)+"%", collectLimit); err != nil {
-				return nil, err
+				return nil, diagnostics, err
 			}
 		}
 	}
@@ -230,7 +248,7 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 				WHERE %s AND e.deleted_at IS NULL AND e.entity_type LIKE ? ESCAPE '\'
 				ORDER BY o.id LIMIT ?
 			`, activeObservationSQL("o")), "%"+escapeLikePattern(term)+"%", collectLimit); err != nil {
-				return nil, err
+				return nil, diagnostics, err
 			}
 		}
 	}
@@ -243,11 +261,11 @@ func CollectCandidates(db *sql.DB, query string, collectLimit, maxCandidates int
 			WHERE %s AND %s AND e.deleted_at IS NULL AND ev.label LIKE ? ESCAPE '\'
 			ORDER BY o.id LIMIT ?
 		`, activeObservationSQL("o"), activeEventSQL("ev")), "%"+escapeLikePattern(trimmed)+"%", collectLimit); err != nil {
-			return nil, err
+			return nil, diagnostics, err
 		}
 	}
 
-	return candidates, nil
+	return candidates, diagnostics, nil
 }
 
 func HydrateCandidates(db dbtx, candidateMap map[int64]*candidate) ([]SearchObservation, error) {
@@ -370,7 +388,7 @@ func SearchMemory(db *sql.DB, query string, limit int, halfLifeWeeks float64) ([
 	if maxCandidates < 200 {
 		maxCandidates = 200
 	}
-	candidates, err := CollectCandidates(db, trimmed, collectLimit, maxCandidates)
+	candidates, diagnostics, err := collectCandidatesWithDiagnostics(db, trimmed, collectLimit, maxCandidates)
 	if err != nil {
 		return nil, SearchMetrics{}, err
 	}
@@ -396,6 +414,7 @@ func SearchMemory(db *sql.DB, query string, limit int, halfLifeWeeks float64) ([
 		ScoreMin:        scoreMin(ranked),
 		ScoreMax:        scoreMax(ranked),
 		ScoreMedian:     scoreMedian(ranked),
+		FTSQueryErrors:  diagnostics.FTSQueryErrors,
 	}
 	return ranked, metrics, nil
 }

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -101,3 +101,41 @@ func TestEscapeLikePattern_QueryVerification(t *testing.T) {
 		t.Fatalf("match = %q, want %q", matches[0], "discount is 50% off")
 	}
 }
+
+func TestSearchMemoryReportsFTSQueryErrorsAndUsesFallback(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "fts-degraded-search.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	entityID, err := UpsertEntity(db, "FTSDegradedEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	if _, err := AddObservation(db, entityID, "fallbackonlytoken survives fts outage", "user", 1.0); err != nil {
+		t.Fatalf("AddObservation() error = %v", err)
+	}
+	if _, err := db.Exec(`DROP TABLE memory_fts`); err != nil {
+		t.Fatalf("drop memory_fts: %v", err)
+	}
+
+	results, metrics, err := SearchMemory(db, "fallbackonlytoken", 5, memoryHalfLifeWeeks())
+	if err != nil {
+		t.Fatalf("SearchMemory() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("SearchMemory() returned %d results, want fallback result: %#v", len(results), results)
+	}
+	if results[0].ID == 0 || results[0].Content != "fallbackonlytoken survives fts outage" {
+		t.Fatalf("SearchMemory() fallback result = %#v", results[0])
+	}
+	if metrics.FTSQueryErrors == 0 {
+		t.Fatalf("SearchMemory() FTSQueryErrors = 0, want degraded signal")
+	}
+	if metrics.Channels["content_like"] == 0 {
+		t.Fatalf("SearchMemory() channels = %#v, want content_like fallback", metrics.Channels)
+	}
+}

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -44,12 +44,13 @@ type ToolArgs struct {
 }
 
 type RememberResult struct {
-	Stored            bool           `json:"stored"`
-	EntityID          int64          `json:"entity_id"`
-	ObservationID     int64          `json:"observation_id"`
-	EventID           *int64         `json:"event_id,omitempty"`
-	Project           *string        `json:"project,omitempty"`
-	PossibleConflicts []ConflictHint `json:"possible_conflicts,omitempty"`
+	Stored                 bool           `json:"stored"`
+	EntityID               int64          `json:"entity_id"`
+	ObservationID          int64          `json:"observation_id"`
+	EventID                *int64         `json:"event_id,omitempty"`
+	Project                *string        `json:"project,omitempty"`
+	PossibleConflicts      []ConflictHint `json:"possible_conflicts,omitempty"`
+	ConflictFTSQueryErrors int            `json:"-"`
 }
 
 type RememberBatchFactResult struct {
@@ -180,7 +181,7 @@ func dispatchTool(defaultDB *sql.DB, name string, args ToolArgs, outMetrics **Se
 		// scope-aware halfLife computed above so project memory uses
 		// its own (longer) decay rate when scoring potential conflicts
 		// — see Kimi general-review finding (PR #11 follow-up).
-		conflicts, err := DetectEntityConflicts(tx, entityID, args.Observation, halfLife)
+		conflicts, conflictFTSQueryErrors, err := DetectEntityConflictsWithDiagnostics(tx, entityID, args.Observation, halfLife)
 		if err != nil {
 			return nil, err
 		}
@@ -191,7 +192,7 @@ func dispatchTool(defaultDB *sql.DB, name string, args ToolArgs, outMetrics **Se
 		if err := tx.Commit(); err != nil {
 			return nil, fmt.Errorf("commit remember: %w", err)
 		}
-		return RememberResult{Stored: true, EntityID: entityID, ObservationID: observationID, EventID: args.EventID, Project: stringPointer(args.Project), PossibleConflicts: conflicts}, nil
+		return RememberResult{Stored: true, EntityID: entityID, ObservationID: observationID, EventID: args.EventID, Project: stringPointer(args.Project), PossibleConflicts: conflicts, ConflictFTSQueryErrors: conflictFTSQueryErrors}, nil
 
 	case "remember_batch":
 		// Scope decision (DECISION_LOG 2026-04-22): conflict detection is

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -183,15 +183,16 @@ func (c *Client) Strict() bool {
 // calls to compute the surface-to-act ratio that calibrates the conflict
 // hint threshold (see DECISION_LOG 2026-04-22).
 type ToolCallInput struct {
-	Tool              string
-	Client            ClientInfo
-	DBScope           string // "global" or "project"
-	ProjectPath       string
-	DurationMs        float64
-	ArgsSummary       string
-	ResultSummary     string
-	IsError           bool
-	ConflictsSurfaced int
+	Tool                   string
+	Client                 ClientInfo
+	DBScope                string // "global" or "project"
+	ProjectPath            string
+	DurationMs             float64
+	ArgsSummary            string
+	ResultSummary          string
+	IsError                bool
+	ConflictsSurfaced      int
+	ConflictFTSQueryErrors int
 }
 
 // LogToolCall inserts a tool_calls row. Returns the new row id on success or
@@ -227,6 +228,7 @@ func (c *Client) LogToolCall(in ToolCallInput) int64 {
 		nullIfEmpty(in.ResultSummary),
 		boolToInt(in.IsError),
 		in.ConflictsSurfaced,
+		in.ConflictFTSQueryErrors,
 	)
 	if err != nil {
 		c.degraded = true
@@ -251,6 +253,7 @@ type SearchMetricsInput struct {
 	ScoreMin        float64
 	ScoreMax        float64
 	ScoreMedian     float64
+	FTSQueryErrors  int
 	Compact         bool
 }
 
@@ -283,6 +286,7 @@ func (c *Client) LogSearchMetrics(in SearchMetricsInput) {
 		in.ScoreMin,
 		in.ScoreMax,
 		in.ScoreMedian,
+		in.FTSQueryErrors,
 		boolToInt(in.Compact),
 	); err != nil {
 		c.degraded = true

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -50,12 +50,13 @@ func TestInitIfEnabledCreatesSchemaAndInserts(t *testing.T) {
 	t.Cleanup(func() { _ = c.Close() })
 
 	id := c.LogToolCall(ToolCallInput{
-		Tool:          "remember",
-		Client:        ClientInfo{Name: "claude-code", Source: "env"},
-		DBScope:       "global",
-		DurationMs:    1.23,
-		ArgsSummary:   `{"entity":"Alice"}`,
-		ResultSummary: `{"stored":true}`,
+		Tool:                   "remember",
+		Client:                 ClientInfo{Name: "claude-code", Source: "env"},
+		DBScope:                "global",
+		DurationMs:             1.23,
+		ArgsSummary:            `{"entity":"Alice"}`,
+		ResultSummary:          `{"stored":true}`,
+		ConflictFTSQueryErrors: 2,
 	})
 	if id == 0 {
 		t.Fatalf("LogToolCall returned 0 on valid client")
@@ -71,6 +72,7 @@ func TestInitIfEnabledCreatesSchemaAndInserts(t *testing.T) {
 		ScoreMin:        0.1,
 		ScoreMax:        0.9,
 		ScoreMedian:     0.5,
+		FTSQueryErrors:  3,
 	})
 
 	// Read back from disk to prove persistence. Use the same DSN pattern as
@@ -97,7 +99,8 @@ func TestInitIfEnabledCreatesSchemaAndInserts(t *testing.T) {
 	}
 
 	var argsSummary, resultSummary, clientName sql.NullString
-	if err := rdb.QueryRow(`SELECT client_name, args_summary, result_summary FROM tool_calls WHERE id = ?`, id).Scan(&clientName, &argsSummary, &resultSummary); err != nil {
+	var conflictFTSErrors int
+	if err := rdb.QueryRow(`SELECT client_name, args_summary, result_summary, conflict_fts_query_errors FROM tool_calls WHERE id = ?`, id).Scan(&clientName, &argsSummary, &resultSummary, &conflictFTSErrors); err != nil {
 		t.Fatalf("readback tool_calls: %v", err)
 	}
 	if clientName.String != "claude-code" {
@@ -105,6 +108,17 @@ func TestInitIfEnabledCreatesSchemaAndInserts(t *testing.T) {
 	}
 	if !strings.Contains(argsSummary.String, "Alice") {
 		t.Fatalf("args_summary missing entity: %q", argsSummary.String)
+	}
+	if conflictFTSErrors != 2 {
+		t.Fatalf("conflict_fts_query_errors = %d, want 2", conflictFTSErrors)
+	}
+
+	var ftsQueryErrors int
+	if err := rdb.QueryRow(`SELECT fts_query_errors FROM search_metrics WHERE tool_call_id = ?`, id).Scan(&ftsQueryErrors); err != nil {
+		t.Fatalf("readback search_metrics fts_query_errors: %v", err)
+	}
+	if ftsQueryErrors != 3 {
+		t.Fatalf("fts_query_errors = %d, want 3", ftsQueryErrors)
 	}
 }
 

--- a/internal/telemetry/migrations.go
+++ b/internal/telemetry/migrations.go
@@ -5,19 +5,31 @@ import (
 	"fmt"
 )
 
-// toolCallsMigrations are idempotent ALTER TABLE operations applied to
-// pre-existing tool_calls tables that were created before a new column
-// was introduced. SQLite does not support ADD COLUMN IF NOT EXISTS, so
-// every migration is guarded by a PRAGMA table_info check. Each entry
-// must also appear in the CREATE TABLE in schema.go so fresh DBs are
-// born at the target shape and the ALTER path short-circuits.
-var toolCallsMigrations = []struct {
+// telemetryMigrations are idempotent ALTER TABLE operations applied to
+// pre-existing telemetry tables that were created before a new column was
+// introduced. SQLite does not support ADD COLUMN IF NOT EXISTS, so every
+// migration is guarded by a PRAGMA table_info check. Each entry must also
+// appear in the CREATE TABLE in schema.go so fresh DBs are born at the target
+// shape and the ALTER path short-circuits.
+var telemetryMigrations = []struct {
+	Table  string
 	Column string
 	Alter  string
 }{
 	{
+		Table:  "tool_calls",
 		Column: "conflicts_surfaced",
 		Alter:  `ALTER TABLE tool_calls ADD COLUMN conflicts_surfaced INTEGER NOT NULL DEFAULT 0`,
+	},
+	{
+		Table:  "tool_calls",
+		Column: "conflict_fts_query_errors",
+		Alter:  `ALTER TABLE tool_calls ADD COLUMN conflict_fts_query_errors INTEGER NOT NULL DEFAULT 0`,
+	},
+	{
+		Table:  "search_metrics",
+		Column: "fts_query_errors",
+		Alter:  `ALTER TABLE search_metrics ADD COLUMN fts_query_errors INTEGER NOT NULL DEFAULT 0`,
 	},
 }
 
@@ -27,8 +39,8 @@ var toolCallsMigrations = []struct {
 // table matches the target shape and every migration becomes a no-op via
 // the columnExists guard. Idempotent: safe to run repeatedly.
 func applyMigrations(db *sql.DB) error {
-	for _, mig := range toolCallsMigrations {
-		present, err := columnExists(db, "tool_calls", mig.Column)
+	for _, mig := range telemetryMigrations {
+		present, err := columnExists(db, mig.Table, mig.Column)
 		if err != nil {
 			return err
 		}
@@ -36,7 +48,7 @@ func applyMigrations(db *sql.DB) error {
 			continue
 		}
 		if _, err := db.Exec(mig.Alter); err != nil {
-			return fmt.Errorf("migrate tool_calls add %s: %w", mig.Column, err)
+			return fmt.Errorf("migrate %s add %s: %w", mig.Table, mig.Column, err)
 		}
 	}
 	return nil
@@ -51,9 +63,9 @@ func applyMigrations(db *sql.DB) error {
 // externally-derived string. SQLite does not support parameter binding
 // inside a PRAGMA expression, so the table name is interpolated via
 // fmt.Sprintf — which would be a SQL injection surface if `table` came
-// from untrusted input. The only current call site passes the literal
-// "tool_calls". Do not export this helper or accept variable table
-// names without re-evaluating the contract.
+// from untrusted input. The only current call site passes literals from
+// telemetryMigrations. Do not export this helper or accept variable table names
+// without re-evaluating the contract.
 func columnExists(db *sql.DB, table, column string) (bool, error) {
 	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
 	if err != nil {

--- a/internal/telemetry/migrations_test.go
+++ b/internal/telemetry/migrations_test.go
@@ -28,6 +28,22 @@ const legacyToolCallsCreateSQL = `CREATE TABLE tool_calls (
     is_error       INTEGER NOT NULL DEFAULT 0
 )`
 
+// legacySearchMetricsCreateSQL mirrors the telemetry schema before
+// fts_query_errors was introduced.
+const legacySearchMetricsCreateSQL = `CREATE TABLE search_metrics (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    tool_call_id     INTEGER REFERENCES tool_calls(id),
+    query            TEXT,
+    channels         TEXT,
+    candidates_total INTEGER,
+    results_returned INTEGER,
+    limit_requested  INTEGER,
+    score_min        REAL,
+    score_max        REAL,
+    score_median     REAL,
+    compact          INTEGER DEFAULT 0
+)`
+
 func openRawTelemetryDB(t *testing.T, path string) *sql.DB {
 	t.Helper()
 	dsn := fmt.Sprintf("file:%s?_pragma=foreign_keys(1)", filepath.Clean(path))
@@ -52,12 +68,22 @@ func TestApplyMigrationsOnFreshDBIsNoop(t *testing.T) {
 	t.Cleanup(func() { _ = c.Close() })
 
 	rdb := openRawTelemetryDB(t, path)
-	present, err := columnExists(rdb, "tool_calls", "conflicts_surfaced")
-	if err != nil {
-		t.Fatalf("columnExists: %v", err)
+	checks := []struct {
+		table  string
+		column string
+	}{
+		{table: "tool_calls", column: "conflicts_surfaced"},
+		{table: "tool_calls", column: "conflict_fts_query_errors"},
+		{table: "search_metrics", column: "fts_query_errors"},
 	}
-	if !present {
-		t.Fatalf("conflicts_surfaced column missing after fresh InitIfEnabled")
+	for _, check := range checks {
+		present, err := columnExists(rdb, check.table, check.column)
+		if err != nil {
+			t.Fatalf("columnExists(%s.%s): %v", check.table, check.column, err)
+		}
+		if !present {
+			t.Fatalf("%s.%s column missing after fresh InitIfEnabled", check.table, check.column)
+		}
 	}
 	// Idempotent second pass must not error.
 	if err := applyMigrations(rdb); err != nil {
@@ -77,37 +103,58 @@ func TestApplyMigrationsUpgradesLegacyDB(t *testing.T) {
 	if _, err := db.Exec(legacyToolCallsCreateSQL); err != nil {
 		t.Fatalf("seed legacy table: %v", err)
 	}
+	if _, err := db.Exec(legacySearchMetricsCreateSQL); err != nil {
+		t.Fatalf("seed legacy search_metrics table: %v", err)
+	}
 	if _, err := db.Exec(`INSERT INTO tool_calls (tool) VALUES ('legacy-row')`); err != nil {
 		t.Fatalf("seed legacy row: %v", err)
 	}
-
-	before, err := columnExists(db, "tool_calls", "conflicts_surfaced")
-	if err != nil {
-		t.Fatalf("columnExists before: %v", err)
+	if _, err := db.Exec(`INSERT INTO search_metrics (tool_call_id, query) VALUES (1, 'legacy-query')`); err != nil {
+		t.Fatalf("seed legacy search_metrics row: %v", err)
 	}
-	if before {
-		t.Fatalf("legacy table already had conflicts_surfaced — test fixture is wrong")
+
+	beforeChecks := []struct {
+		table  string
+		column string
+	}{
+		{table: "tool_calls", column: "conflicts_surfaced"},
+		{table: "tool_calls", column: "conflict_fts_query_errors"},
+		{table: "search_metrics", column: "fts_query_errors"},
+	}
+	for _, check := range beforeChecks {
+		before, err := columnExists(db, check.table, check.column)
+		if err != nil {
+			t.Fatalf("columnExists(%s.%s) before: %v", check.table, check.column, err)
+		}
+		if before {
+			t.Fatalf("legacy table already had %s.%s — test fixture is wrong", check.table, check.column)
+		}
 	}
 
 	if err := applyMigrations(db); err != nil {
 		t.Fatalf("applyMigrations on legacy: %v", err)
 	}
 
-	after, err := columnExists(db, "tool_calls", "conflicts_surfaced")
-	if err != nil {
-		t.Fatalf("columnExists after: %v", err)
-	}
-	if !after {
-		t.Fatalf("conflicts_surfaced column missing after migration")
+	for _, check := range beforeChecks {
+		after, err := columnExists(db, check.table, check.column)
+		if err != nil {
+			t.Fatalf("columnExists(%s.%s) after: %v", check.table, check.column, err)
+		}
+		if !after {
+			t.Fatalf("%s.%s column missing after migration", check.table, check.column)
+		}
 	}
 
 	// Existing rows get the NOT NULL DEFAULT 0 from the ADD COLUMN.
-	var legacyValue int
-	if err := db.QueryRow(`SELECT conflicts_surfaced FROM tool_calls WHERE tool = 'legacy-row'`).Scan(&legacyValue); err != nil {
-		t.Fatalf("read legacy row conflicts_surfaced: %v", err)
+	var conflictsSurfaced, conflictFTSErrors, searchFTSErrors int
+	if err := db.QueryRow(`SELECT conflicts_surfaced, conflict_fts_query_errors FROM tool_calls WHERE tool = 'legacy-row'`).Scan(&conflictsSurfaced, &conflictFTSErrors); err != nil {
+		t.Fatalf("read legacy row tool_calls migration columns: %v", err)
 	}
-	if legacyValue != 0 {
-		t.Fatalf("legacy row conflicts_surfaced = %d, want 0 (ADD COLUMN default)", legacyValue)
+	if err := db.QueryRow(`SELECT fts_query_errors FROM search_metrics WHERE query = 'legacy-query'`).Scan(&searchFTSErrors); err != nil {
+		t.Fatalf("read legacy row search_metrics.fts_query_errors: %v", err)
+	}
+	if conflictsSurfaced != 0 || conflictFTSErrors != 0 || searchFTSErrors != 0 {
+		t.Fatalf("legacy migration defaults = conflicts:%d conflict_fts:%d search_fts:%d, want all 0", conflictsSurfaced, conflictFTSErrors, searchFTSErrors)
 	}
 
 	// Second application is a pure no-op.
@@ -137,7 +184,7 @@ func TestLogToolCallPersistsConflictsSurfaced(t *testing.T) {
 	}
 	ids := make(map[string]int64, len(cases))
 	for _, tc := range cases {
-		id := c.LogToolCall(ToolCallInput{Tool: tc.tool, ConflictsSurfaced: tc.count})
+		id := c.LogToolCall(ToolCallInput{Tool: tc.tool, ConflictsSurfaced: tc.count, ConflictFTSQueryErrors: tc.count + 10})
 		if id == 0 {
 			t.Fatalf("LogToolCall(%q) returned 0", tc.name)
 		}
@@ -146,12 +193,15 @@ func TestLogToolCallPersistsConflictsSurfaced(t *testing.T) {
 
 	rdb := openRawTelemetryDB(t, path)
 	for _, tc := range cases {
-		var stored int
-		if err := rdb.QueryRow(`SELECT conflicts_surfaced FROM tool_calls WHERE id = ?`, ids[tc.name]).Scan(&stored); err != nil {
+		var stored, storedFTSErrors int
+		if err := rdb.QueryRow(`SELECT conflicts_surfaced, conflict_fts_query_errors FROM tool_calls WHERE id = ?`, ids[tc.name]).Scan(&stored, &storedFTSErrors); err != nil {
 			t.Fatalf("readback %q: %v", tc.name, err)
 		}
 		if stored != tc.count {
 			t.Fatalf("%q conflicts_surfaced = %d, want %d", tc.name, stored, tc.count)
+		}
+		if storedFTSErrors != tc.count+10 {
+			t.Fatalf("%q conflict_fts_query_errors = %d, want %d", tc.name, storedFTSErrors, tc.count+10)
 		}
 	}
 }

--- a/internal/telemetry/schema.go
+++ b/internal/telemetry/schema.go
@@ -5,10 +5,10 @@ package telemetry
 // internal/store/sqlite.go InitSchema) — more portable across SQLite
 // drivers than chaining multiple statements into one db.Exec call.
 //
-// New columns added to tool_calls after initial release are declared in the
-// CREATE TABLE below AND paired with an entry in toolCallsMigrations so
-// existing DBs can catch up via ALTER TABLE (see migrations.go). SQLite
-// does not support ADD COLUMN IF NOT EXISTS, so this pair is the idiom.
+// New columns added after initial release are declared in the CREATE TABLE
+// below AND paired with an entry in telemetryMigrations so existing DBs can
+// catch up via ALTER TABLE (see migrations.go). SQLite does not support ADD
+// COLUMN IF NOT EXISTS, so this pair is the idiom.
 var schemaStatements = []string{
 	`CREATE TABLE IF NOT EXISTS tool_calls (
     id                 INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -22,8 +22,9 @@ var schemaStatements = []string{
     duration_ms        REAL,
     args_summary       TEXT,
     result_summary     TEXT,
-    is_error           INTEGER NOT NULL DEFAULT 0,
-    conflicts_surfaced INTEGER NOT NULL DEFAULT 0
+    is_error                  INTEGER NOT NULL DEFAULT 0,
+    conflicts_surfaced        INTEGER NOT NULL DEFAULT 0,
+    conflict_fts_query_errors INTEGER NOT NULL DEFAULT 0
 )`,
 	`CREATE TABLE IF NOT EXISTS search_metrics (
     id               INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -36,6 +37,7 @@ var schemaStatements = []string{
     score_min        REAL,
     score_max        REAL,
     score_median     REAL,
+    fts_query_errors INTEGER NOT NULL DEFAULT 0,
     compact          INTEGER DEFAULT 0
 )`,
 	`CREATE INDEX IF NOT EXISTS idx_tool_calls_ts ON tool_calls(ts)`,
@@ -45,10 +47,10 @@ var schemaStatements = []string{
 
 const (
 	insertCallSQL = `INSERT INTO tool_calls
-	(tool, client_name, client_version, client_source, db_scope, project_path, duration_ms, args_summary, result_summary, is_error, conflicts_surfaced)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	(tool, client_name, client_version, client_source, db_scope, project_path, duration_ms, args_summary, result_summary, is_error, conflicts_surfaced, conflict_fts_query_errors)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	insertSearchSQL = `INSERT INTO search_metrics
-	(tool_call_id, query, channels, candidates_total, results_returned, limit_requested, score_min, score_max, score_median, compact)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	(tool_call_id, query, channels, candidates_total, results_returned, limit_requested, score_min, score_max, score_median, fts_query_errors, compact)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 )


### PR DESCRIPTION
## Summary
- report non-fatal FTS query failures in recall telemetry and remember conflict telemetry
- preserve fallback behavior through LIKE/entity channels when FTS `MATCH` queries fail
- update telemetry schema, migrations, docs, and regression tests for fresh and legacy DBs

## Validation
- `gofmt`
- `go test ./...`
- `git diff --check`

## Notes
- Local GLM mini-review found 0 blockers before commit.
- This closes the R4 active debt item by making FTS degradation observable without making fallback search fail.