### PR TITLE
fix(store): evict idle project db handles

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,7 +56,7 @@ The `entity_type` must come from the **observation row** (`entity_type` column),
 Any tool that accepts a `project` parameter routes to a per-project SQLite DB at `<project>/.memory/memory.db` (created lazily). The global default DB lives at `MEMORY_DB_PATH`.
 
 - `ResolveProjectPath` — always use this to expand `~` and relative paths
-- `GetDB` — returns the correct DB for a tool call, lazy-opens and caches per project
+- `AcquireDB` — returns the correct leased DB for a tool call, lazy-opens and caches per project; release every lease
 - Half-life: global = `MEMORY_HALF_LIFE_WEEKS` (12), project = `PROJECT_MEMORY_HALF_LIFE_WEEKS` (52)
 
 ## Composite scoring pipeline
@@ -75,13 +75,13 @@ Any tool that accepts a `project` parameter routes to a per-project SQLite DB at
 Every tool must:
 1. Be registered in `mcpserver/server.go` with correct schema
 2. Have a case in `HandleTool` in `tools.go`
-3. Route through `GetDB` to respect project scoping
+3. Route through `AcquireDB` to respect project scoping and release project DB leases
 4. Pass the correct half-life (project vs global)
 
 ## No hardcoding
 
 - Config comes from env vars. Defaults in `config.go`.
-- `MEMORY_DB_PATH`, `MEMORY_HALF_LIFE_WEEKS`, `PROJECT_MEMORY_HALF_LIFE_WEEKS`, `COMPACT_SNIPPET_LENGTH`
+- `MEMORY_DB_PATH`, `MEMORY_HALF_LIFE_WEEKS`, `PROJECT_MEMORY_HALF_LIFE_WEEKS`, `COMPACT_SNIPPET_LENGTH`, `PROJECT_DB_CACHE_MAX`
 
 ## SQL safety
 

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -39,13 +39,13 @@ The `entity_type` must come from the **observation row** (`entity_type` column o
 
 - Is the tool registered in `mcpserver/server.go` with correct JSON schema?
 - Is there a case in `HandleTool` in `tools.go`?
-- Does the handler call `GetDB` to respect project scoping?
+- Does the handler call `AcquireDB` and release the returned lease to respect project scoping?
 - Does it pass the correct half-life (project vs global)?
 
 ### 4. Multi-tenant isolation
 
 - Any code touching the filesystem must use `ResolveProjectPath` — never raw `filepath.Join` on untrusted input
-- Project DBs are cached via `GetDB`. Never open DBs directly.
+- Project DBs are cached via `AcquireDB`. Never open DBs directly.
 - A query must never cross-contaminate global and project DBs.
 
 ### 5. Scoring pipeline integrity

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -23,6 +23,7 @@
 - `remember` must commit `UpsertEntity`, conflict detection, and `AddObservation` atomically. If observation insert fails after entity upsert, neither entity nor observation may survive. Conflict detection still runs before inserting the new observation.
 - `relate` must commit endpoint entity upserts and relation insert atomically. If relation insertion fails for a non-idempotent reason, newly created endpoint entities must roll back; duplicate relations remain idempotent and return "Relation already exists".
 - FTS `MATCH` query failures in search/conflict candidate collection are non-fatal only when fallback channels can continue, and must emit a degraded signal: `search_metrics.fts_query_errors` for recall, `tool_calls.conflict_fts_query_errors` for remember conflict detection.
+- Project-scoped DB handles use leased access through `AcquireDB`; idle handles over the `PROJECT_DB_CACHE_MAX` target must be evicted and closed without touching the global DB handle.
 
 ## Active Debt
 
@@ -71,12 +72,6 @@ Done when: FTS-specific parity tests pass across the release matrix.
 - Cross-build CI currently compiles with `CGO_ENABLED=0`; that matches the single-binary intent, but the runtime FTS proof is still stronger on real test runs than on cross-compiled artifacts alone.
 
 ### P2
-
-- Project-scoped DB handles are cached indefinitely for the process lifetime.
-Trigger: A long-running MCP server touches many distinct project paths over time.
-Blast radius: The `projectDBs` map and open SQLite file descriptors grow until shutdown; small personal use is fine, broad workspace use can leak resources.
-Fix: Add a bounded cache with lazy close/eviction, or an explicit max cap with deterministic close behavior.
-Done when: a regression test opens more than the cap and proves older project DB handles are closed/evicted without breaking active global storage.
 
 - Schema migrations are still inline `ALTER TABLE` statements guarded by duplicate-schema string matching.
 Trigger: Adding more migrations before replacing the guard with explicit migration tracking.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Each project gets its own isolated SQLite database at `<project>/.memory/memory.
 | `MEMORY_HALF_LIFE_WEEKS` | `12` | Decay half-life for global memory |
 | `PROJECT_MEMORY_HALF_LIFE_WEEKS` | `52` | Decay half-life for project memory |
 | `COMPACT_SNIPPET_LENGTH` | `120` | Max chars per observation in compact mode |
+| `PROJECT_DB_CACHE_MAX` | `16` | Target max cached project-scoped SQLite handles; active leases may temporarily exceed it |
 
 ### Loading config from a .env file
 

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -6,6 +6,7 @@ import (
 )
 
 const defaultCompactSnippetLength = 120
+const defaultProjectDBCacheMax = 16
 
 // Config getters read the process environment on every call so that values
 // injected late (e.g., by the dotenv loader in main before mcpserver.New)
@@ -22,6 +23,10 @@ func projectMemoryHalfLifeWeeks() float64 {
 
 func compactSnippetLength() int {
 	return envInt("COMPACT_SNIPPET_LENGTH", defaultCompactSnippetLength)
+}
+
+func projectDBCacheMax() int {
+	return envInt("PROJECT_DB_CACHE_MAX", defaultProjectDBCacheMax)
 }
 
 func envFloat(key string, fallback float64) float64 {

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -649,10 +649,11 @@ func TestProjectIsolationParity(t *testing.T) {
 		_ = ResetProjectDBs()
 	})
 
-	projectDB, err := GetDB(db, projectPath)
+	projectDB, releaseProjectDB, err := AcquireDB(db, projectPath)
 	if err != nil {
-		t.Fatalf("GetDB(project) error = %v", err)
+		t.Fatalf("AcquireDB(project) error = %v", err)
 	}
+	defer releaseProjectDB()
 	entityID, err := UpsertEntity(projectDB, "ProjectOnly", "test")
 	if err != nil {
 		t.Fatalf("UpsertEntity(project) error = %v", err)

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"container/list"
 	"database/sql"
 	"fmt"
 	"os"
@@ -9,9 +10,16 @@ import (
 )
 
 var (
-	projectDBMu sync.Mutex
-	projectDBs  = map[string]*sql.DB{}
+	projectDBMu  sync.Mutex
+	projectDBs   = map[string]*projectDBEntry{}
+	projectDBLRU = list.New()
 )
+
+type projectDBEntry struct {
+	db   *sql.DB
+	refs int
+	elem *list.Element
+}
 
 func ResolveProjectPath(project string, homedir string) string {
 	if homedir == "" {
@@ -29,29 +37,38 @@ func ResolveProjectPath(project string, homedir string) string {
 	return filepath.Join(homedir, project)
 }
 
-func GetDB(defaultDB *sql.DB, project string) (*sql.DB, error) {
+// AcquireDB returns the global DB for empty project scope or a leased project
+// DB handle for project scope. Callers must invoke the returned release
+// function once they are done with the handle so idle project handles can be
+// evicted when PROJECT_DB_CACHE_MAX is exceeded. The release function is
+// idempotent.
+func AcquireDB(defaultDB *sql.DB, project string) (*sql.DB, func(), error) {
 	if project == "" {
-		return defaultDB, nil
+		return defaultDB, func() {}, nil
 	}
 
 	resolved := ResolveProjectPath(project, "")
 	projectDBMu.Lock()
-	defer projectDBMu.Unlock()
 
 	if existing, ok := projectDBs[resolved]; ok {
-		return existing, nil
+		existing.refs++
+		projectDBLRU.MoveToFront(existing.elem)
+		projectDBMu.Unlock()
+		return existing.db, projectDBRelease(resolved), nil
 	}
 
 	dbDir := filepath.Join(resolved, ".memory")
 	created := false
 	if _, err := os.Stat(dbDir); err != nil {
 		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("stat project memory dir: %w", err)
+			projectDBMu.Unlock()
+			return nil, nil, fmt.Errorf("stat project memory dir: %w", err)
 		}
 		created = true
 	}
 	if err := os.MkdirAll(dbDir, 0o700); err != nil {
-		return nil, fmt.Errorf("create project memory dir: %w", err)
+		projectDBMu.Unlock()
+		return nil, nil, fmt.Errorf("create project memory dir: %w", err)
 	}
 	if created {
 		_ = os.Chmod(dbDir, 0o700)
@@ -59,24 +76,101 @@ func GetDB(defaultDB *sql.DB, project string) (*sql.DB, error) {
 	dbPath := filepath.Join(dbDir, "memory.db")
 	db, err := InitDB(dbPath)
 	if err != nil {
-		return nil, err
+		projectDBMu.Unlock()
+		return nil, nil, err
 	}
-	projectDBs[resolved] = db
-	return db, nil
+	projectDBs[resolved] = &projectDBEntry{
+		db:   db,
+		refs: 1,
+		elem: projectDBLRU.PushFront(resolved),
+	}
+	toClose := evictProjectDBsLocked(projectDBCacheMax())
+	projectDBMu.Unlock()
+	closeProjectDBs(toClose)
+	return db, projectDBRelease(resolved), nil
+}
+
+func projectDBRelease(resolved string) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			projectDBMu.Lock()
+			if entry, ok := projectDBs[resolved]; ok && entry.refs > 0 {
+				entry.refs--
+			}
+			toClose := evictProjectDBsLocked(projectDBCacheMax())
+			projectDBMu.Unlock()
+			closeProjectDBs(toClose)
+		})
+	}
+}
+
+func evictProjectDBsLocked(maxEntries int) []*sql.DB {
+	if maxEntries <= 0 {
+		maxEntries = defaultProjectDBCacheMax
+	}
+
+	var toClose []*sql.DB
+	for len(projectDBs) > maxEntries {
+		var evicted bool
+		for elem := projectDBLRU.Back(); elem != nil; {
+			prev := elem.Prev()
+			key, ok := elem.Value.(string)
+			if !ok {
+				projectDBLRU.Remove(elem)
+				elem = prev
+				continue
+			}
+			entry := projectDBs[key]
+			if entry != nil && entry.refs == 0 {
+				delete(projectDBs, key)
+				projectDBLRU.Remove(elem)
+				toClose = append(toClose, entry.db)
+				evicted = true
+				break
+			}
+			elem = prev
+		}
+		if !evicted {
+			break
+		}
+	}
+	return toClose
+}
+
+func closeProjectDBs(dbs []*sql.DB) {
+	for _, db := range dbs {
+		// Checkpoint WAL before close — ensures Windows releases file handles.
+		_, _ = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+		_ = db.Close()
+	}
 }
 
 func ResetProjectDBs() error {
 	projectDBMu.Lock()
-	defer projectDBMu.Unlock()
+
+	toClose := make([]*sql.DB, 0, len(projectDBs))
+	activeRefs := 0
+	for key, entry := range projectDBs {
+		if entry != nil {
+			activeRefs += entry.refs
+			toClose = append(toClose, entry.db)
+		}
+		delete(projectDBs, key)
+	}
+	projectDBLRU.Init()
+	projectDBMu.Unlock()
 
 	var firstErr error
-	for key, db := range projectDBs {
+	for _, db := range toClose {
 		// Checkpoint WAL before close — ensures Windows releases file handles
 		_, _ = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
 		if err := db.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
-		delete(projectDBs, key)
+	}
+	if activeRefs > 0 && firstErr == nil {
+		firstErr = fmt.Errorf("reset project DBs with %d active lease(s)", activeRefs)
 	}
 	return firstErr
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -205,6 +205,9 @@ func TestProjectDBCacheEvictsLeastRecentlyUsedIdleHandle(t *testing.T) {
 	if err := ResetProjectDBs(); err != nil {
 		t.Fatalf("ResetProjectDBs() pre-test error = %v", err)
 	}
+	root := t.TempDir()
+	// Register after t.TempDir so ResetProjectDBs closes SQLite handles before
+	// Windows attempts to remove the project directories.
 	t.Cleanup(func() {
 		if err := ResetProjectDBs(); err != nil {
 			t.Fatalf("ResetProjectDBs() cleanup error = %v", err)
@@ -212,15 +215,15 @@ func TestProjectDBCacheEvictsLeastRecentlyUsedIdleHandle(t *testing.T) {
 	})
 	t.Setenv("PROJECT_DB_CACHE_MAX", "2")
 
-	defaultDB, err := InitDB(filepath.Join(t.TempDir(), "default.db"))
+	defaultDB, err := InitDB(filepath.Join(root, "default.db"))
 	if err != nil {
 		t.Fatalf("InitDB(default) error = %v", err)
 	}
 	defer defaultDB.Close()
 
-	projectA := filepath.Join(t.TempDir(), "project-a")
-	projectB := filepath.Join(t.TempDir(), "project-b")
-	projectC := filepath.Join(t.TempDir(), "project-c")
+	projectA := filepath.Join(root, "project-a")
+	projectB := filepath.Join(root, "project-b")
+	projectC := filepath.Join(root, "project-c")
 
 	dbA, releaseA, err := AcquireDB(defaultDB, projectA)
 	if err != nil {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -129,9 +129,11 @@ func TestProjectDBCreatesPrivateMemoryDirectory(t *testing.T) {
 	})
 
 	projectRoot := filepath.Join(t.TempDir(), "project")
-	if _, err := GetDB(defaultDB, projectRoot); err != nil {
-		t.Fatalf("GetDB(project) error = %v", err)
+	_, releaseProjectDB, err := AcquireDB(defaultDB, projectRoot)
+	if err != nil {
+		t.Fatalf("AcquireDB(project) error = %v", err)
 	}
+	releaseProjectDB()
 
 	memoryDir := filepath.Join(projectRoot, ".memory")
 	info, err := os.Stat(memoryDir)
@@ -176,9 +178,11 @@ func TestProjectDBDoesNotTightenExistingMemoryDirectory(t *testing.T) {
 		t.Fatalf("chmod existing project .memory error = %v", err)
 	}
 
-	if _, err := GetDB(defaultDB, projectRoot); err != nil {
-		t.Fatalf("GetDB(project) error = %v", err)
+	_, releaseProjectDB, err := AcquireDB(defaultDB, projectRoot)
+	if err != nil {
+		t.Fatalf("AcquireDB(project) error = %v", err)
 	}
+	releaseProjectDB()
 
 	info, err := os.Stat(memoryDir)
 	if err != nil {
@@ -194,6 +198,95 @@ func TestProjectDBDoesNotTightenExistingMemoryDirectory(t *testing.T) {
 	}
 	if got := dbInfo.Mode().Perm(); got != 0o600 {
 		t.Fatalf("project memory.db mode = %o, want 600", got)
+	}
+}
+
+func TestProjectDBCacheEvictsLeastRecentlyUsedIdleHandle(t *testing.T) {
+	if err := ResetProjectDBs(); err != nil {
+		t.Fatalf("ResetProjectDBs() pre-test error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := ResetProjectDBs(); err != nil {
+			t.Fatalf("ResetProjectDBs() cleanup error = %v", err)
+		}
+	})
+	t.Setenv("PROJECT_DB_CACHE_MAX", "2")
+
+	defaultDB, err := InitDB(filepath.Join(t.TempDir(), "default.db"))
+	if err != nil {
+		t.Fatalf("InitDB(default) error = %v", err)
+	}
+	defer defaultDB.Close()
+
+	projectA := filepath.Join(t.TempDir(), "project-a")
+	projectB := filepath.Join(t.TempDir(), "project-b")
+	projectC := filepath.Join(t.TempDir(), "project-c")
+
+	dbA, releaseA, err := AcquireDB(defaultDB, projectA)
+	if err != nil {
+		t.Fatalf("AcquireDB(projectA) error = %v", err)
+	}
+	if _, err := UpsertEntity(dbA, "ProjectA", "test"); err != nil {
+		t.Fatalf("UpsertEntity(projectA) error = %v", err)
+	}
+	releaseA()
+
+	dbB, releaseB, err := AcquireDB(defaultDB, projectB)
+	if err != nil {
+		t.Fatalf("AcquireDB(projectB) error = %v", err)
+	}
+	if _, err := UpsertEntity(dbB, "ProjectB", "test"); err != nil {
+		t.Fatalf("UpsertEntity(projectB) error = %v", err)
+	}
+	releaseB()
+
+	dbAAgain, releaseAAgain, err := AcquireDB(defaultDB, projectA)
+	if err != nil {
+		t.Fatalf("AcquireDB(projectA again) error = %v", err)
+	}
+	if dbAAgain != dbA {
+		t.Fatalf("projectA cache hit returned a different handle before eviction")
+	}
+	releaseAAgain()
+
+	dbC, releaseC, err := AcquireDB(defaultDB, projectC)
+	if err != nil {
+		t.Fatalf("AcquireDB(projectC) error = %v", err)
+	}
+	defer releaseC()
+
+	if err := dbB.Ping(); err == nil {
+		t.Fatalf("least-recently-used projectB handle still accepts queries after cap eviction")
+	}
+	if err := dbA.Ping(); err != nil {
+		t.Fatalf("recently used projectA handle was evicted: %v", err)
+	}
+	if err := dbC.Ping(); err != nil {
+		t.Fatalf("new projectC handle is unusable: %v", err)
+	}
+
+	dbBReopened, releaseBReopened, err := AcquireDB(defaultDB, projectB)
+	if err != nil {
+		t.Fatalf("AcquireDB(projectB reopened) error = %v", err)
+	}
+	defer releaseBReopened()
+	if dbBReopened == dbB {
+		t.Fatalf("projectB reopened with the closed evicted handle")
+	}
+	var projectBCount int
+	if err := dbBReopened.QueryRow(`SELECT COUNT(*) FROM entities WHERE name = 'ProjectB'`).Scan(&projectBCount); err != nil {
+		t.Fatalf("read projectB reopened data error = %v", err)
+	}
+	if projectBCount != 1 {
+		t.Fatalf("projectB reopened count = %d, want persisted data", projectBCount)
+	}
+
+	globalID, err := UpsertEntity(defaultDB, "GlobalAfterEviction", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity(global) after project eviction error = %v", err)
+	}
+	if globalID == 0 {
+		t.Fatalf("UpsertEntity(global) returned id 0 after project eviction")
 	}
 }
 

--- a/internal/store/tools.go
+++ b/internal/store/tools.go
@@ -152,10 +152,11 @@ func dispatchTool(defaultDB *sql.DB, name string, args ToolArgs, outMetrics **Se
 		return nil, err
 	}
 
-	db, err := GetDB(defaultDB, args.Project)
+	db, releaseDB, err := AcquireDB(defaultDB, args.Project)
 	if err != nil {
 		return nil, err
 	}
+	defer releaseDB()
 	halfLife := memoryHalfLifeWeeks()
 	if args.Project != "" {
 		halfLife = projectMemoryHalfLifeWeeks()


### PR DESCRIPTION
## Summary
- replace the unbounded project DB map with leased `AcquireDB` access and LRU eviction of idle handles over `PROJECT_DB_CACHE_MAX`
- keep active project handles protected by a refcount and leave the global DB outside eviction
- document the new cache cap and update project-scoping review instructions

## Validation
- `gofmt`
- `go test ./...`
- `git diff --check`
- VSCode code checker: no issues

## Review
- GLM correctness mini-review found no blockers.
- Followed up on review risks by renaming `GetDB` to `AcquireDB`, documenting the soft target cap, making `ResetProjectDBs` report active leases, and guarding the LRU type assertion.