### PR TITLE
fix(store): version schema migrations

### DIFF
--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -1,5 +1,44 @@
 # DECISION LOG
 
+## 2026-04-26: Schema migrations are version-stamped, not duplicate-error driven
+
+### Context
+
+The main store still relied on unversioned `ALTER TABLE` statements wrapped by
+string matching for duplicate-schema errors. That made idempotency depend on
+driver error text and obscured which migrations had actually been applied.
+Telemetry migrations used safer column introspection, but they also lacked an
+explicit registry.
+
+### Decision
+
+Add a `schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)`
+registry to both the main store DB and the telemetry DB. Fresh/current-shape DBs
+stamp migration versions when the target column already exists. Legacy DBs run
+only missing migrations, then stamp the same version. Each migration runs inside
+its own transaction.
+
+For legacy main-store DBs, create indexes that depend on migrated columns only
+after migrations run. Legacy entity timestamp columns are added without a
+non-constant SQLite default and protected with explicit insert timestamps plus
+a fallback insert trigger.
+
+### Rationale
+
+- Migration state should be data, not inferred from error strings.
+- Fresh DBs and already-upgraded DBs must be idempotent without rerunning
+  duplicate `ALTER TABLE` statements.
+- Legacy DB upgrades need tests that prove both column addition and registry
+  stamping.
+
+### Alternatives considered
+
+- **Keep duplicate-error suppression.** Rejected because it can hide real
+  migration errors and depends on driver wording.
+- **Rebuild legacy tables to exactly match fresh constraints.** Deferred as too
+  broad for this hardening PR; the compatibility-critical timestamp behavior is
+  preserved through explicit writes and a trigger.
+
 ## 2026-04-26: Event expiry is a lifecycle guard, not just an event-list filter
 
 ### Context

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -24,6 +24,7 @@
 - `relate` must commit endpoint entity upserts and relation insert atomically. If relation insertion fails for a non-idempotent reason, newly created endpoint entities must roll back; duplicate relations remain idempotent and return "Relation already exists".
 - FTS `MATCH` query failures in search/conflict candidate collection are non-fatal only when fallback channels can continue, and must emit a degraded signal: `search_metrics.fts_query_errors` for recall, `tool_calls.conflict_fts_query_errors` for remember conflict detection.
 - Project-scoped DB handles use leased access through `AcquireDB`; idle handles over the `PROJECT_DB_CACHE_MAX` target must be evicted and closed without touching the global DB handle.
+- Schema upgrades are version-stamped in `schema_migrations`; fresh/current-shape DBs stamp already-present columns, while legacy DBs run only missing migrations.
 
 ## Active Debt
 
@@ -73,15 +74,10 @@ Done when: FTS-specific parity tests pass across the release matrix.
 
 ### P2
 
-- Schema migrations are still inline `ALTER TABLE` statements guarded by duplicate-schema string matching.
-Trigger: Adding more migrations before replacing the guard with explicit migration tracking.
-Blast radius: A real migration error could be mistaken for an idempotent duplicate-schema condition, or a legacy DB path could drift from fresh schema behavior.
-Fix: add `schema_migrations(version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)` before v1; keep fresh `CREATE TABLE IF NOT EXISTS` bootstrap and prove legacy upgrades with regression tests.
-Done when: each migration has a version, runs once, and legacy-schema tests no longer depend on string-matching duplicate column errors.
+- None yet.
 
 ## Pre-Launch TODO
 
-- Prove schema initialization and migrations on clean and upgraded DBs.
 - Prove forget semantics including FTS deletion.
 - Prove project isolation.
 - Prove release artifacts for macOS, Linux, and Windows.

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -14,10 +14,76 @@ import (
 
 const sqliteDriverName = "sqlite"
 
+const schemaMigrationsCreateSQL = `CREATE TABLE IF NOT EXISTS schema_migrations (
+	version INTEGER PRIMARY KEY,
+	applied_at TEXT NOT NULL
+);`
+
 type dbtx interface {
 	Exec(query string, args ...any) (sql.Result, error)
 	Query(query string, args ...any) (*sql.Rows, error)
 	QueryRow(query string, args ...any) *sql.Row
+}
+
+type schemaMigration struct {
+	Version int
+	Table   string
+	Column  string
+	SQL     string
+	PostSQL []string
+}
+
+var schemaMigrations = []schemaMigration{
+	{
+		Version: 1,
+		Table:   "observations",
+		Column:  "event_id",
+		SQL:     `ALTER TABLE observations ADD COLUMN event_id INTEGER REFERENCES events(id)`,
+	},
+	{
+		Version: 2,
+		Table:   "entities",
+		Column:  "deleted_at",
+		SQL:     `ALTER TABLE entities ADD COLUMN deleted_at TEXT`,
+	},
+	{
+		Version: 3,
+		Table:   "observations",
+		Column:  "deleted_at",
+		SQL:     `ALTER TABLE observations ADD COLUMN deleted_at TEXT`,
+	},
+	{
+		Version: 4,
+		Table:   "observations",
+		Column:  "entity_type",
+		SQL:     `ALTER TABLE observations ADD COLUMN entity_type TEXT`,
+	},
+	{
+		Version: 5,
+		Table:   "observations",
+		Column:  "access_count",
+		SQL:     `ALTER TABLE observations ADD COLUMN access_count INTEGER DEFAULT 0`,
+	},
+	{
+		Version: 6,
+		Table:   "observations",
+		Column:  "last_accessed",
+		SQL:     `ALTER TABLE observations ADD COLUMN last_accessed TEXT`,
+	},
+	{
+		Version: 7,
+		Table:   "entities",
+		Column:  "created_at",
+		SQL:     `ALTER TABLE entities ADD COLUMN created_at TEXT`,
+		PostSQL: []string{`UPDATE entities SET created_at = COALESCE(created_at, CURRENT_TIMESTAMP)`},
+	},
+	{
+		Version: 8,
+		Table:   "entities",
+		Column:  "updated_at",
+		SQL:     `ALTER TABLE entities ADD COLUMN updated_at TEXT`,
+		PostSQL: []string{`UPDATE entities SET updated_at = COALESCE(updated_at, CURRENT_TIMESTAMP)`},
+	},
 }
 
 type CanaryResult struct {
@@ -200,6 +266,7 @@ func hardenSQLiteFiles(dbPath string) {
 
 func InitSchema(db *sql.DB) error {
 	stmts := []string{
+		schemaMigrationsCreateSQL,
 		`CREATE TABLE IF NOT EXISTS entities (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			name TEXT NOT NULL UNIQUE COLLATE NOCASE,
@@ -250,7 +317,6 @@ func InitSchema(db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_events_date ON events(event_date);`,
 		`CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);`,
 		`CREATE INDEX IF NOT EXISTS idx_events_label ON events(label);`,
-		`CREATE INDEX IF NOT EXISTS idx_obs_event ON observations(event_id);`,
 		`CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
 			entity_name,
 			observation_content,
@@ -265,25 +331,23 @@ func InitSchema(db *sql.DB) error {
 		}
 	}
 
-	migrations := []string{
-		`ALTER TABLE observations ADD COLUMN event_id INTEGER REFERENCES events(id)`,
-		`ALTER TABLE entities ADD COLUMN deleted_at TEXT`,
-		`ALTER TABLE observations ADD COLUMN deleted_at TEXT`,
-		`ALTER TABLE observations ADD COLUMN entity_type TEXT`,
-		`ALTER TABLE observations ADD COLUMN access_count INTEGER DEFAULT 0`,
-		`ALTER TABLE observations ADD COLUMN last_accessed TEXT`,
-		`ALTER TABLE entities ADD COLUMN created_at TEXT DEFAULT CURRENT_TIMESTAMP`,
-		`ALTER TABLE entities ADD COLUMN updated_at TEXT DEFAULT CURRENT_TIMESTAMP`,
-	}
-	for _, stmt := range migrations {
-		if err := execIgnoreDuplicateSchemaChange(db, stmt); err != nil {
-			return fmt.Errorf("apply migration %q: %w", stmt, err)
-		}
+	if err := applySchemaMigrations(db); err != nil {
+		return err
 	}
 
 	postMigrationStmts := []string{
+		`CREATE INDEX IF NOT EXISTS idx_obs_event ON observations(event_id);`,
 		`CREATE INDEX IF NOT EXISTS idx_entities_deleted ON entities(deleted_at);`,
 		`CREATE INDEX IF NOT EXISTS idx_obs_deleted ON observations(deleted_at);`,
+		`CREATE TRIGGER IF NOT EXISTS trg_entities_insert_timestamps
+			AFTER INSERT ON entities
+			WHEN NEW.created_at IS NULL OR NEW.updated_at IS NULL
+			BEGIN
+				UPDATE entities
+				SET created_at = COALESCE(created_at, CURRENT_TIMESTAMP),
+					updated_at = COALESCE(updated_at, CURRENT_TIMESTAMP)
+				WHERE id = NEW.id;
+			END;`,
 	}
 	for _, stmt := range postMigrationStmts {
 		if _, err := db.Exec(stmt); err != nil {
@@ -291,6 +355,93 @@ func InitSchema(db *sql.DB) error {
 		}
 	}
 	return nil
+}
+
+func applySchemaMigrations(db *sql.DB) error {
+	if _, err := db.Exec(schemaMigrationsCreateSQL); err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+	for _, migration := range schemaMigrations {
+		if err := applySchemaMigration(db, migration); err != nil {
+			return fmt.Errorf("apply migration %d: %w", migration.Version, err)
+		}
+	}
+	return nil
+}
+
+func applySchemaMigration(db *sql.DB, migration schemaMigration) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin migration transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	applied, err := migrationApplied(tx, migration.Version)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return tx.Commit()
+	}
+
+	present, err := columnExists(tx, migration.Table, migration.Column)
+	if err != nil {
+		return err
+	}
+	if !present {
+		if _, err := tx.Exec(migration.SQL); err != nil {
+			return fmt.Errorf("execute schema migration: %w", err)
+		}
+		for _, stmt := range migration.PostSQL {
+			if _, err := tx.Exec(stmt); err != nil {
+				return fmt.Errorf("execute schema migration post-step: %w", err)
+			}
+		}
+	}
+	if _, err := tx.Exec(`INSERT INTO schema_migrations (version, applied_at) VALUES (?, strftime('%Y-%m-%dT%H:%M:%f', 'now'))`, migration.Version); err != nil {
+		return fmt.Errorf("record schema migration: %w", err)
+	}
+	return tx.Commit()
+}
+
+func migrationApplied(db dbtx, version int) (bool, error) {
+	var applied int
+	err := db.QueryRow(`SELECT 1 FROM schema_migrations WHERE version = ?`, version).Scan(&applied)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, fmt.Errorf("check schema migration %d: %w", version, err)
+}
+
+// columnExists reports whether a column is present on the given SQLite table.
+// Callers must pass hardcoded table literals; SQLite does not support binding
+// identifiers in PRAGMA table_info.
+func columnExists(db dbtx, table, column string) (bool, error) {
+	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return false, fmt.Errorf("pragma table_info(%s): %w", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			typ     string
+			notnull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk); err != nil {
+			return false, fmt.Errorf("scan pragma table_info(%s): %w", table, err)
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
 }
 
 func UpsertEntity(db dbtx, name, entityType string) (int64, error) {
@@ -317,7 +468,7 @@ func UpsertEntity(db dbtx, name, entityType string) (int64, error) {
 		return 0, fmt.Errorf("lookup entity: %w", err)
 	}
 
-	result, err := db.Exec(`INSERT INTO entities (name, entity_type) VALUES (?, ?)`, name, nullableString(entityType, ""))
+	result, err := db.Exec(`INSERT INTO entities (name, entity_type, created_at, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, name, nullableString(entityType, ""))
 	if err != nil {
 		return 0, fmt.Errorf("insert entity: %w", err)
 	}
@@ -662,16 +813,4 @@ func placeholders(count int) string {
 		parts[i] = "?"
 	}
 	return strings.Join(parts, ",")
-}
-
-func execIgnoreDuplicateSchemaChange(db *sql.DB, stmt string) error {
-	_, err := db.Exec(stmt)
-	if err == nil {
-		return nil
-	}
-	msg := strings.ToLower(err.Error())
-	if strings.Contains(msg, "duplicate column name") || strings.Contains(msg, "already exists") {
-		return nil
-	}
-	return err
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
@@ -293,6 +294,30 @@ func TestProjectDBCacheEvictsLeastRecentlyUsedIdleHandle(t *testing.T) {
 	}
 }
 
+func TestInitDBRecordsSchemaMigrationsAndIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "migration-registry.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	assertSchemaMigrationCount(t, db, len(schemaMigrations))
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema() second pass error = %v", err)
+	}
+	assertSchemaMigrationCount(t, db, len(schemaMigrations))
+
+	var missingAppliedAt int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations WHERE applied_at = ''`).Scan(&missingAppliedAt); err != nil {
+		t.Fatalf("read schema_migrations applied_at error = %v", err)
+	}
+	if missingAppliedAt != 0 {
+		t.Fatalf("schema_migrations rows with empty applied_at = %d, want 0", missingAppliedAt)
+	}
+}
+
 func TestSearchObservationIDsHonorsExpiryGuard(t *testing.T) {
 	t.Parallel()
 
@@ -493,5 +518,132 @@ func TestInitDBMigratesLegacyProjectSchemaBeforeDeletedIndexes(t *testing.T) {
 	}
 	if deletedIndexCount != 1 {
 		t.Fatalf("idx_entities_deleted count = %d, want 1", deletedIndexCount)
+	}
+	assertSchemaMigrationCount(t, migratedDB, len(schemaMigrations))
+	if err := InitSchema(migratedDB); err != nil {
+		t.Fatalf("InitSchema() second pass on legacy migration error = %v", err)
+	}
+	assertSchemaMigrationCount(t, migratedDB, len(schemaMigrations))
+}
+
+func TestInitDBMigratesPreRegistryLegacySchema(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "pre-registry-legacy.db")
+	legacyDB, err := openSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("openSQLite(legacy) error = %v", err)
+	}
+	legacySchema := []string{
+		`CREATE TABLE entities (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE COLLATE NOCASE,
+			entity_type TEXT
+		);`,
+		`CREATE TABLE observations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			entity_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+			content TEXT NOT NULL,
+			source TEXT DEFAULT 'user',
+			confidence REAL DEFAULT 1.0,
+			access_count INTEGER DEFAULT 0,
+			last_accessed TEXT,
+			created_at TEXT DEFAULT (datetime('now'))
+		);`,
+		`CREATE TABLE relations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			from_entity_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+			to_entity_id INTEGER NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+			relation_type TEXT NOT NULL,
+			context TEXT,
+			created_at TEXT DEFAULT (datetime('now')),
+			UNIQUE(from_entity_id, to_entity_id, relation_type)
+		);`,
+		`CREATE TABLE events (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			label TEXT NOT NULL,
+			event_date TEXT,
+			event_type TEXT,
+			context TEXT,
+			expires_at TEXT,
+			created_at TEXT DEFAULT (datetime('now'))
+		);`,
+	}
+	for _, stmt := range legacySchema {
+		if _, err := legacyDB.Exec(stmt); err != nil {
+			legacyDB.Close()
+			t.Fatalf("seed pre-registry legacy schema statement failed: %v", err)
+		}
+	}
+	if err := legacyDB.Close(); err != nil {
+		t.Fatalf("legacyDB.Close() error = %v", err)
+	}
+
+	migratedDB, err := InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("InitDB() on pre-registry legacy schema error = %v", err)
+	}
+	defer migratedDB.Close()
+	assertSchemaMigrationCount(t, migratedDB, len(schemaMigrations))
+
+	for _, check := range []struct {
+		table  string
+		column string
+	}{
+		{table: "entities", column: "deleted_at"},
+		{table: "observations", column: "event_id"},
+		{table: "observations", column: "deleted_at"},
+		{table: "observations", column: "entity_type"},
+		{table: "entities", column: "created_at"},
+		{table: "entities", column: "updated_at"},
+	} {
+		present, err := columnExists(migratedDB, check.table, check.column)
+		if err != nil {
+			t.Fatalf("columnExists(%s.%s) error = %v", check.table, check.column, err)
+		}
+		if !present {
+			t.Fatalf("%s.%s missing after migration", check.table, check.column)
+		}
+	}
+
+	var eventIndexCount int
+	if err := migratedDB.QueryRow(`SELECT COUNT(*) FROM pragma_index_list('observations') WHERE name = 'idx_obs_event'`).Scan(&eventIndexCount); err != nil {
+		t.Fatalf("pragma_index_list(observations) error = %v", err)
+	}
+	if eventIndexCount != 1 {
+		t.Fatalf("idx_obs_event count = %d, want 1", eventIndexCount)
+	}
+
+	entityID, err := UpsertEntity(migratedDB, "LegacyTimestampProbe", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() after timestamp migration error = %v", err)
+	}
+	var createdAt, updatedAt string
+	if err := migratedDB.QueryRow(`SELECT created_at, updated_at FROM entities WHERE id = ?`, entityID).Scan(&createdAt, &updatedAt); err != nil {
+		t.Fatalf("read migrated entity timestamps error = %v", err)
+	}
+	if createdAt == "" || updatedAt == "" {
+		t.Fatalf("created_at=%q updated_at=%q, want populated timestamps", createdAt, updatedAt)
+	}
+
+	if _, err := migratedDB.Exec(`INSERT INTO entities (name, entity_type) VALUES ('DirectLegacyInsert', 'test')`); err != nil {
+		t.Fatalf("direct legacy entity insert error = %v", err)
+	}
+	if err := migratedDB.QueryRow(`SELECT created_at, updated_at FROM entities WHERE name = 'DirectLegacyInsert'`).Scan(&createdAt, &updatedAt); err != nil {
+		t.Fatalf("read direct legacy insert timestamps error = %v", err)
+	}
+	if createdAt == "" || updatedAt == "" {
+		t.Fatalf("direct insert created_at=%q updated_at=%q, want trigger-populated timestamps", createdAt, updatedAt)
+	}
+}
+
+func assertSchemaMigrationCount(t *testing.T, db *sql.DB, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&got); err != nil {
+		t.Fatalf("count schema_migrations error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("schema_migrations count = %d, want %d", got, want)
 	}
 }

--- a/internal/telemetry/migrations.go
+++ b/internal/telemetry/migrations.go
@@ -2,56 +2,104 @@ package telemetry
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 )
 
-// telemetryMigrations are idempotent ALTER TABLE operations applied to
+// telemetryMigrations are versioned ALTER TABLE operations applied to
 // pre-existing telemetry tables that were created before a new column was
-// introduced. SQLite does not support ADD COLUMN IF NOT EXISTS, so every
-// migration is guarded by a PRAGMA table_info check. Each entry must also
-// appear in the CREATE TABLE in schema.go so fresh DBs are born at the target
-// shape and the ALTER path short-circuits.
-var telemetryMigrations = []struct {
-	Table  string
-	Column string
-	Alter  string
-}{
+// introduced. Each entry must also appear in the CREATE TABLE in schema.go so
+// fresh DBs are born at the target shape and get stamped as already applied.
+var telemetryMigrations = []telemetryMigration{
 	{
-		Table:  "tool_calls",
-		Column: "conflicts_surfaced",
-		Alter:  `ALTER TABLE tool_calls ADD COLUMN conflicts_surfaced INTEGER NOT NULL DEFAULT 0`,
+		Version: 1,
+		Table:   "tool_calls",
+		Column:  "conflicts_surfaced",
+		Alter:   `ALTER TABLE tool_calls ADD COLUMN conflicts_surfaced INTEGER NOT NULL DEFAULT 0`,
 	},
 	{
-		Table:  "tool_calls",
-		Column: "conflict_fts_query_errors",
-		Alter:  `ALTER TABLE tool_calls ADD COLUMN conflict_fts_query_errors INTEGER NOT NULL DEFAULT 0`,
+		Version: 2,
+		Table:   "tool_calls",
+		Column:  "conflict_fts_query_errors",
+		Alter:   `ALTER TABLE tool_calls ADD COLUMN conflict_fts_query_errors INTEGER NOT NULL DEFAULT 0`,
 	},
 	{
-		Table:  "search_metrics",
-		Column: "fts_query_errors",
-		Alter:  `ALTER TABLE search_metrics ADD COLUMN fts_query_errors INTEGER NOT NULL DEFAULT 0`,
+		Version: 3,
+		Table:   "search_metrics",
+		Column:  "fts_query_errors",
+		Alter:   `ALTER TABLE search_metrics ADD COLUMN fts_query_errors INTEGER NOT NULL DEFAULT 0`,
 	},
 }
 
-// applyMigrations brings an existing telemetry DB up to the current schema
-// without erroring on columns that already exist. Called after the CREATE
-// TABLE IF NOT EXISTS statements in InitIfEnabled, so a freshly-created
-// table matches the target shape and every migration becomes a no-op via
-// the columnExists guard. Idempotent: safe to run repeatedly.
+type telemetryMigration struct {
+	Version int
+	Table   string
+	Column  string
+	Alter   string
+}
+
+// applyMigrations brings an existing telemetry DB up to the current schema.
+// Called after the CREATE TABLE IF NOT EXISTS statements in InitIfEnabled, so a
+// freshly-created table matches the target shape and every migration stamps the
+// registry without running ALTER. Idempotent: safe to run repeatedly.
 func applyMigrations(db *sql.DB) error {
+	if _, err := db.Exec(schemaMigrationsCreateSQL); err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
 	for _, mig := range telemetryMigrations {
-		present, err := columnExists(db, mig.Table, mig.Column)
-		if err != nil {
-			return err
-		}
-		if present {
-			continue
-		}
-		if _, err := db.Exec(mig.Alter); err != nil {
+		if err := applyMigration(db, mig); err != nil {
 			return fmt.Errorf("migrate %s add %s: %w", mig.Table, mig.Column, err)
 		}
 	}
 	return nil
+}
+
+func applyMigration(db *sql.DB, mig telemetryMigration) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin migration transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	applied, err := migrationApplied(tx, mig.Version)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return tx.Commit()
+	}
+
+	present, err := columnExists(tx, mig.Table, mig.Column)
+	if err != nil {
+		return err
+	}
+	if !present {
+		if _, err := tx.Exec(mig.Alter); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(`INSERT INTO schema_migrations (version, applied_at) VALUES (?, strftime('%Y-%m-%dT%H:%M:%f', 'now'))`, mig.Version); err != nil {
+		return fmt.Errorf("record migration: %w", err)
+	}
+	return tx.Commit()
+}
+
+func migrationApplied(db migrationDB, version int) (bool, error) {
+	var applied int
+	err := db.QueryRow(`SELECT 1 FROM schema_migrations WHERE version = ?`, version).Scan(&applied)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, fmt.Errorf("check schema migration %d: %w", version, err)
+}
+
+type migrationDB interface {
+	Exec(query string, args ...any) (sql.Result, error)
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
 }
 
 // columnExists reports whether a column is present on the given SQLite
@@ -66,7 +114,7 @@ func applyMigrations(db *sql.DB) error {
 // from untrusted input. The only current call site passes literals from
 // telemetryMigrations. Do not export this helper or accept variable table names
 // without re-evaluating the contract.
-func columnExists(db *sql.DB, table, column string) (bool, error) {
+func columnExists(db migrationDB, table, column string) (bool, error) {
 	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
 	if err != nil {
 		return false, fmt.Errorf("pragma table_info(%s): %w", table, err)

--- a/internal/telemetry/migrations_test.go
+++ b/internal/telemetry/migrations_test.go
@@ -55,6 +55,17 @@ func openRawTelemetryDB(t *testing.T, path string) *sql.DB {
 	return db
 }
 
+func assertSchemaMigrationCount(t *testing.T, db *sql.DB, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&got); err != nil {
+		t.Fatalf("count schema_migrations error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("schema_migrations count = %d, want %d", got, want)
+	}
+}
+
 func TestApplyMigrationsOnFreshDBIsNoop(t *testing.T) {
 	t.Parallel()
 	// InitIfEnabled runs applyMigrations as part of setup; the column must
@@ -85,6 +96,7 @@ func TestApplyMigrationsOnFreshDBIsNoop(t *testing.T) {
 			t.Fatalf("%s.%s column missing after fresh InitIfEnabled", check.table, check.column)
 		}
 	}
+	assertSchemaMigrationCount(t, rdb, len(telemetryMigrations))
 	// Idempotent second pass must not error.
 	if err := applyMigrations(rdb); err != nil {
 		t.Fatalf("applyMigrations second pass: %v", err)
@@ -92,6 +104,7 @@ func TestApplyMigrationsOnFreshDBIsNoop(t *testing.T) {
 	if err := applyMigrations(rdb); err != nil {
 		t.Fatalf("applyMigrations third pass: %v", err)
 	}
+	assertSchemaMigrationCount(t, rdb, len(telemetryMigrations))
 }
 
 func TestApplyMigrationsUpgradesLegacyDB(t *testing.T) {
@@ -156,11 +169,13 @@ func TestApplyMigrationsUpgradesLegacyDB(t *testing.T) {
 	if conflictsSurfaced != 0 || conflictFTSErrors != 0 || searchFTSErrors != 0 {
 		t.Fatalf("legacy migration defaults = conflicts:%d conflict_fts:%d search_fts:%d, want all 0", conflictsSurfaced, conflictFTSErrors, searchFTSErrors)
 	}
+	assertSchemaMigrationCount(t, db, len(telemetryMigrations))
 
 	// Second application is a pure no-op.
 	if err := applyMigrations(db); err != nil {
 		t.Fatalf("applyMigrations second pass: %v", err)
 	}
+	assertSchemaMigrationCount(t, db, len(telemetryMigrations))
 }
 
 func TestLogToolCallPersistsConflictsSurfaced(t *testing.T) {

--- a/internal/telemetry/schema.go
+++ b/internal/telemetry/schema.go
@@ -1,15 +1,21 @@
 package telemetry
 
+const schemaMigrationsCreateSQL = `CREATE TABLE IF NOT EXISTS schema_migrations (
+    version    INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+)`
+
 // schemaStatements is executed one-by-one by InitIfEnabled. The main store
 // follows the same single-statement-per-Exec pattern (see
 // internal/store/sqlite.go InitSchema) — more portable across SQLite
 // drivers than chaining multiple statements into one db.Exec call.
 //
 // New columns added after initial release are declared in the CREATE TABLE
-// below AND paired with an entry in telemetryMigrations so existing DBs can
-// catch up via ALTER TABLE (see migrations.go). SQLite does not support ADD
-// COLUMN IF NOT EXISTS, so this pair is the idiom.
+// below AND paired with a versioned entry in telemetryMigrations so existing
+// DBs can catch up via ALTER TABLE while fresh/current-shape DBs stamp the
+// registry without re-running ALTER statements (see migrations.go).
 var schemaStatements = []string{
+	schemaMigrationsCreateSQL,
 	`CREATE TABLE IF NOT EXISTS tool_calls (
     id                 INTEGER PRIMARY KEY AUTOINCREMENT,
     ts                 TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now')),


### PR DESCRIPTION
## Summary
- add `schema_migrations(version, applied_at)` registries for the main store and telemetry DBs
- replace duplicate-schema string suppression with versioned, transactional migrations that stamp fresh/current-shape DBs and alter only missing legacy columns
- move migration-dependent indexes after migrations and cover pre-registry legacy schema upgrades
- document the migration policy in OPERATIONS and DECISION_LOG

## Validation
- `gofmt`
- `go test ./...`
- `git diff --check`
- VSCode code checker: no issues

## Review
- GLM correctness mini-review found no blockers.
- Followed up by covering deleted-column checks, aligning telemetry `ErrNoRows` handling, and preserving legacy timestamp insert behavior with explicit timestamps plus a fallback trigger.