### PR TITLE
ci: run sqlite canary on test matrix

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -21,6 +21,8 @@ jobs:
           go-version-file: go.mod
       - name: Run tests
         run: go test ./...
+      - name: Run SQLite/FTS runtime canary
+        run: go run ./cmd/workmem sqlite-canary
 
   build:
     name: Cross-build artifacts

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -13,7 +13,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            canary_artifact: workmem
+            canary_command: ./workmem sqlite-canary
+          - os: macos-latest
+            canary_artifact: workmem
+            canary_command: ./workmem sqlite-canary
+          - os: windows-latest
+            canary_artifact: workmem.exe
+            canary_command: .\workmem.exe sqlite-canary
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -21,8 +30,10 @@ jobs:
           go-version-file: go.mod
       - name: Run tests
         run: go test ./...
+      - name: Build CLI for runtime canary
+        run: go build -o ${{ matrix.canary_artifact }} ./cmd/workmem
       - name: Run SQLite/FTS runtime canary
-        run: go run ./cmd/workmem sqlite-canary
+        run: ${{ matrix.canary_command }}
 
   build:
     name: Cross-build artifacts

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -52,25 +52,13 @@ Blast radius: Drift from the JS reference can sneak in when both sides evolve in
 Fix: add a JS-side fixture runner and compare normalized outputs in CI.
 Done when: shared fixtures execute against both runtimes with diffable results.
 
-- The current driver choice is validated only on local canary paths, not yet on cross-platform release targets.
-Trigger: Treating a passing macOS canary as full portability proof.
-Blast radius: Late failures on Linux or Windows packaging, or FTS behavior drift under different builds.
-Fix: Keep the canary in CI and run it on at least macOS, Linux, and Windows before calling the persistence layer portable.
-Done when: the same schema/FTS canary passes in cross-build validation.
-
-- FTS5 viability is proven locally on the chosen driver, but not yet in a cross-platform validation matrix.
-Trigger: Assuming a passing local canary implies release-target portability.
-Blast radius: Search or forget semantics break only after packaging or OS expansion.
-Fix: Run the same canary on macOS, Linux, and Windows targets.
-Done when: FTS-specific parity tests pass across the release matrix.
-
 ### Driver caveats
 
 - The first proven driver is `modernc.org/sqlite`, not the Node reference stack's `better-sqlite3` binding.
-- The current canary passes schema init, foreign-key enforcement, contentless FTS insert/match/delete, and persistence reopen on `darwin/arm64`.
+- The runtime SQLite/FTS canary runs in CI on macOS, Linux, and Windows. It proves schema init, foreign-key enforcement, contentless FTS insert/match/delete, tombstone persistence, and reopen persistence on each host OS.
 - The store currently forces `SetMaxOpenConns(1)` to keep the early SQLite path deterministic while the persistence layer is still thin.
 - The FTS delete path must keep using the observation-row snapshot of `entity_type`; reading live `entities.entity_type` after mutation is not safe.
-- Cross-build CI currently compiles with `CGO_ENABLED=0`; that matches the single-binary intent, but the runtime FTS proof is still stronger on real test runs than on cross-compiled artifacts alone.
+- Cross-build CI still compiles release-target artifacts with `CGO_ENABLED=0`; host-runtime canary jobs cover SQLite/FTS behavior, while cross-build jobs cover artifact compilation.
 
 ### P2
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ On macOS, Gatekeeper will warn on first launch of an unsigned binary downloaded 
 ```bash
 git clone https://github.com/marlian/workmem.git
 cd workmem
+go test ./...
+go run ./cmd/workmem sqlite-canary
 go build -o workmem ./cmd/workmem
 ./workmem version   # prints "workmem dev" without -ldflags
 ```


### PR DESCRIPTION
## Summary
- run the `workmem sqlite-canary` CLI path in the existing macOS/Linux/Windows test matrix
- close the cross-platform SQLite/FTS runtime canary debt in OPERATIONS
- document local source-build validation with `go test ./...` and `go run ./cmd/workmem sqlite-canary`

## Validation
- `go test ./...`
- `go run ./cmd/workmem sqlite-canary`
- `git diff --check`
- VSCode code checker: no issues