### PR TITLE
docs: make go implementation canonical

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,12 +31,13 @@ testdata/contracts/          — shared behavioral fixtures
 
 ## Database schema
 
-Four tables. Soft-delete via `deleted_at TEXT` applies only to `entities` and `observations`:
+Five ordinary tables plus the contentless FTS table. Soft-delete via `deleted_at TEXT` applies only to `entities` and `observations`:
 
 - `entities` — named objects (`name UNIQUE COLLATE NOCASE`, `entity_type`, `deleted_at`, timestamps)
 - `observations` — atomic facts linked to an entity (`entity_id`, `content`, `source`, `confidence`, `access_count`, `last_accessed`, `deleted_at`, `event_id`, `entity_type` snapshot, timestamps)
 - `relations` — typed edges between entities — **no soft-delete**, hard-deleted when entity is tombstoned
 - `events` — grouped sessions/meetings/decisions (`label`, `event_date`, `event_type`, `context`, `expires_at`) — **no soft-delete**
+- `schema_migrations` — version registry for schema upgrades (`version`, `applied_at`)
 
 **Invariant:** every query that reads live data **must** have `deleted_at IS NULL` guards on both `entities` and `observations`. Missing this guard is a tombstone bypass bug.
 

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -79,12 +79,12 @@ If a PR touches `SearchMemory`, `CollectCandidates`, `HydrateCandidates`, or `Sc
 
 ## Telemetry design rationale (do NOT flag)
 
-- Telemetry is not yet ported to Go — this is intentional (deferred to post-parity)
-- When ported: query text, entity names, and labels are stored in plaintext in the telemetry DB. This is a local, single-user dev tool. Redacting structural fields makes analysis useless.
+- Telemetry is opt-in via `MEMORY_TELEMETRY_PATH`; when unset, no telemetry DB is created and tool correctness must be unchanged.
+- `MEMORY_TELEMETRY_PRIVACY=strict` hashes entity/query/label values before storage. Default telemetry keeps structural fields useful for local analysis; never let telemetry failures break tool calls.
 
 ## What NOT to flag
 
 - Package layout choices (store vs mcpserver split) — intentional
 - `modernc.org/sqlite` instead of `mattn/go-sqlite3` — deliberate CGO-free choice
-- Missing features from the Node version not yet ported — check OPERATIONS.md for tracked debt
+- Missing features from the legacy Node implementation — `workmem` is now the canonical product; check `API_CONTRACT.md` and `OPERATIONS.md` for tracked obligations
 - The tool count being exactly 12 — this is a design constraint, not an oversight

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -42,24 +42,27 @@ The Go implementation should preserve the MCP tool surface unless there is a del
 
 ## Compatibility policy
 
-Until the Go port is clearly stronger than the Node server, API compatibility beats elegance.
+The Go `workmem` implementation is the canonical product. API compatibility
+means preserving the documented MCP contract, not chasing the legacy Node
+implementation.
 
 That means:
 
 - preserve tool names
 - preserve major argument names
 - preserve response shape where practical
-- document every intentional divergence
+- document every intentional contract change
 
-The initial comparison fixtures live in `testdata/contracts/` and are the baseline for Step 1.3 parity work.
+The product-contract fixtures live in `testdata/contracts/` and define the
+minimum externally visible behavior that must stay stable across refactors.
 
-## Allowed early deviations
+## Allowed internal changes
 
 - internal implementation details
 - telemetry internals
 - non-user-visible refactors
 
-## Not allowed to drift early
+## Not allowed to drift silently
 
 - forget semantics
 - project routing behavior
@@ -67,13 +70,11 @@ The initial comparison fixtures live in `testdata/contracts/` and are the baseli
 - compact recall behavior
 - provenance response shape without explicit migration notes
 
-## Additive response extensions (post-parity)
+## Additive response extensions
 
-Once core parity is proven and the product starts earning its own
-evolutionary decisions, the tool surface can grow *additively* on
-existing responses without changing any tool name, argument name, or
-documented field. Clients that do not know about a new field must keep
-working unchanged.
+The tool surface can grow *additively* on existing responses without changing
+any tool name, argument name, or documented field. Clients that do not know
+about a new field must keep working unchanged.
 
 ### `remember` — `possible_conflicts`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,9 @@
 
 ## Goal
 
-Rebuild the current MCP memory server as a native Go binary while preserving the user-facing behavior that matters.
+Define the current `workmem` architecture: a local-first MCP memory server
+implemented as a native Go binary, backed by SQLite, and distributed as a
+single executable.
 
 ## High-level shape
 
@@ -12,7 +14,7 @@ Rebuild the current MCP memory server as a native Go binary while preserving the
 - Packaging: single compiled binary per target OS and architecture
 - Deployment model: local executable launched by MCP clients
 
-## Planned layers
+## Layers
 
 ### 1. MCP transport
 
@@ -31,7 +33,7 @@ Responsible for:
 - tool semantics
 - project-vs-global routing
 - result shaping
-- compatibility behavior for recall and provenance primitives
+- documented behavior for recall and provenance primitives
 
 ### 3. Persistence layer
 
@@ -80,20 +82,23 @@ Global memory and project memory must remain physically and logically separate.
 
 Search must overcollect, hydrate, score, rank, and only then touch returned observations.
 
-## Expected package layout
+## Package layout
 
-This is provisional and should stay small:
+The codebase should stay small and auditable:
 
 ```text
 cmd/workmem/
-internal/mcp/
-internal/app/
+internal/backup/
+internal/dotenv/
+internal/mcpserver/
 internal/store/
-internal/search/
 internal/telemetry/
+docs/
 testdata/
 ```
 
 ## Deliberate constraint
 
-Do not over-abstract early. The current Node implementation is valuable partly because it is easy to audit. The Go port should preserve that clarity rather than turning a small server into a framework.
+Do not over-abstract. The product is valuable partly because a local memory
+server can be audited as a small system. Keep the Go codebase direct instead
+of turning it into a framework.

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -1,5 +1,39 @@
 # DECISION LOG
 
+## 2026-04-27: Go workmem is canonical; Node parity is retired
+
+### Context
+
+The Go implementation has moved beyond the legacy Node implementation in
+packaging, telemetry, migration safety, project DB lifecycle management,
+privacy hardening, and CI runtime proof. Keeping Node-vs-Go comparison as an
+active goal now creates false authority: the abandoned implementation is no
+longer the best oracle for current product behavior.
+
+### Decision
+
+Treat `workmem` as the canonical product. The source of truth is now the
+documented MCP contract, product fixtures, operational invariants, and decision
+log entries. The legacy Node implementation is historical context, not an
+active compatibility target.
+
+### Rationale
+
+- Contract stability should be measured against current documented behavior,
+  not an abandoned implementation.
+- The Go codebase now has stronger runtime and migration guarantees than the
+  Node reference-era docs assumed.
+- Removing the Node oracle avoids wasting CI and review attention on drift that
+  no longer matters to users.
+
+### Alternatives considered
+
+- **Keep dual-runtime parity as a P1.** Rejected. It would compare against a
+  stale reference and slow down useful hardening work.
+- **Delete all historical Node mentions.** Rejected. Historical decision-log
+  context remains useful; only active docs should stop treating Node as the
+  reference.
+
 ## 2026-04-26: Schema migrations are version-stamped, not duplicate-error driven
 
 ### Context

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -6,7 +6,7 @@ Establish that a Go binary can support the real product semantics, not just comp
 
 ### Step 1.1: Repo bootstrap [✅]
 
-Brief description. **Gate:** canonical docs exist and the rewrite scope is explicit.
+Brief description. **Gate:** canonical docs exist and the implementation scope is explicit.
 
 - [x] Create the new repository folder in user home
 - [x] Write core project docs
@@ -26,19 +26,19 @@ Brief description. **Gate:** canary program proves schema init, FTS insert/match
 
 **On Step Gate (all items [x]):** trigger focused review on SQLite semantics.
 
-### Step 1.3: Compatibility harness definition [✅]
+### Step 1.3: Product-contract harness definition [✅]
 
-Brief description. **Gate:** a small contract matrix exists for Node-vs-Go comparison on core paths.
+Brief description. **Gate:** a small product-contract matrix exists for core paths.
 
-- [x] Identify must-preserve behaviors from the current server
+- [x] Identify must-preserve product behaviors
 - [x] Separate product-contract tests from implementation-detail tests
 - [x] Define fixtures for remember, recall, forget, and project isolation
 
 **On Step Gate (all items [x]):** trigger correctness review.
 
-## Phase 2: Core Product Parity [✅]
+## Phase 2: Core Product Surface [✅]
 
-Deliver the minimum feature set needed for the port to feel real.
+Deliver the minimum feature set needed for workmem to feel real.
 
 ### Step 2.1: Core memory operations [✅]
 
@@ -48,7 +48,7 @@ Brief description. **Gate:** `remember`, `recall`, `forget`, and `list_entities`
 - [x] Implement entity upsert and observation insert
 - [x] Implement recall candidate collection and ranking skeleton
 - [x] Implement forget semantics with tombstones and FTS cleanup
-- [x] Verify returned behavior through compatibility fixtures
+- [x] Verify returned behavior through product-contract fixtures
 
 **On Step Gate (all items [x]):** trigger tripartite review + Integration Pulse.
 
@@ -64,7 +64,7 @@ Brief description. **Gate:** project DB routing is isolated and deterministic.
 
 ## Phase 3: Full Surface And Packaging [✅]
 
-Reach operational parity and distribution quality.
+Reach operational completeness and distribution quality.
 
 ### Step 3.1: Remaining tools and telemetry [✅]
 
@@ -72,16 +72,16 @@ Brief description. **Gate:** events, provenance tools, and telemetry plan are im
 
 - [x] Implement events and provenance primitives
 - [x] Port compact recall behavior
-- [x] Defer minimal telemetry with docs until the Go transport layer exists
+- [x] Initially defer minimal telemetry with docs until the transport layer exists
 - [x] Decide telemetry compatibility scope
 
 **On Step Gate (all items [x]):** trigger tripartite review + Integration Pulse.
 
 ### Step 3.2: MCP stdio transport [✅]
 
-Brief description. **Gate:** the Go binary exposes the parity tool surface over MCP stdio and survives a real command-transport smoke test.
+Brief description. **Gate:** the Go binary exposes the documented tool surface over MCP stdio and survives a real command-transport smoke test.
 
-- [x] Register the parity tool surface with MCP schemas
+- [x] Register the documented tool surface with MCP schemas
 - [x] Bridge tool calls into the existing Go store backend
 - [x] Prove stdio command transport against the Go binary entrypoint
 
@@ -112,7 +112,7 @@ Ship a `workmem backup` subcommand that produces an age-encrypted snapshot of th
 
 ### Step 3.5: Telemetry [✅]
 
-Port the Node telemetry design to Go with Go-native refinements and a new privacy-strict mode. **Gate:** when `MEMORY_TELEMETRY_PATH` is set, every tool call lands a row in `tool_calls`; every `recall` lands a row in `search_metrics` linked by `tool_call_id`; when unset, no DB is created and no overhead is added. In `MEMORY_TELEMETRY_PRIVACY=strict` mode, entity/query/label values are sha256-hashed before storage.
+Implement opt-in telemetry with Go-native lifecycle management and a new privacy-strict mode. **Gate:** when `MEMORY_TELEMETRY_PATH` is set, every tool call lands a row in `tool_calls`; every `recall` lands a row in `search_metrics` linked by `tool_call_id`; when unset, no DB is created and no overhead is added. In `MEMORY_TELEMETRY_PRIVACY=strict` mode, entity/query/label values are sha256-hashed before storage.
 
 - [x] Build `internal/telemetry` package (nil-tolerant Client, schema, sanitize, hash, detect)
 - [x] Refactor `SearchMemory` to return `(results, metrics, err)` — no globals, no side channels
@@ -125,11 +125,11 @@ Port the Node telemetry design to Go with Go-native refinements and a new privac
 
 **On Step Gate (all items [x]):** trigger correctness review on telemetry hook points and strict-mode hashing.
 
-## Phase 4: Behavioral refinements [🔧]
+## Phase 4: Behavioral refinements and hardening [✅]
 
-Evolve workmem beyond Node parity. Each step is motivated by telemetry
-evidence, not speculation, and every step ships a measurement path so
-its own effectiveness becomes observable.
+Evolve workmem through evidence-backed behavior and hardening. Each behavioral
+change ships a measurement path or invariant so its effectiveness becomes
+observable.
 
 ### Step 4.1: Conflict hints in `remember` response [✅]
 
@@ -205,3 +205,39 @@ failure.
 
 **On Step Gate (all items [x]):** trigger focused correctness/security
 review before release tagging.
+
+### Step 4.3: Post-review operational hardening [✅]
+
+Close risks surfaced after the first hardening/review pass. **Gate:** CI is
+green across host OS tests and cross-builds, active security/privacy/resource
+risks are closed or explicitly deferred, and docs reflect the current Go
+canonical architecture.
+
+- [x] Redact malformed sensitive telemetry arguments before persistence
+- [x] Validate `confidence` and case-insensitive self-relations before writes
+- [x] Make `remember` and `relate` transactional across their dependent writes
+- [x] Emit telemetry when FTS `MATCH` queries degrade and fallback paths continue
+- [x] Bound project-scoped SQLite handle caching with leased `AcquireDB` access
+- [x] Replace duplicate-schema error matching with versioned `schema_migrations`
+- [x] Run the SQLite/FTS runtime canary from the built CLI on macOS, Linux, and Windows CI jobs
+
+**On Step Gate (all items [x]):** focused reviews per PR plus CI matrix proof.
+
+## Phase 5: Evidence-driven tuning [🔧]
+
+Use production telemetry to tune behavior only after enough data exists. No
+threshold changes happen on vibes.
+
+### Step 5.1: Conflict-hint threshold calibration [⏸]
+
+Wait for the sampling window defined in `OPERATIONS.md`: at least 200
+`remember` calls across two or more active projects, or 4 weeks of real use.
+**Gate:** telemetry analysis either confirms `conflictHintMinScore = 0.6` twice
+or records an evidence-backed adjustment in `DECISION_LOG.md`.
+
+- [ ] Collect the telemetry sampling window
+- [ ] Run the telemetry analysis split by `tool_calls.db_scope`
+- [ ] Record the threshold decision and evidence summary
+
+**On Step Gate (all items [x]):** correctness review focused on threshold
+evidence and false-positive/false-negative trade-offs.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -2,11 +2,11 @@
 
 ## Invariants
 
-- The Go port must remain a local-first, single-binary MCP stdio server.
+- workmem must remain a local-first, single-binary MCP stdio server.
 - Core behavior comes before feature count.
 - Telemetry must remain optional and side-effect free when disabled.
 - SQLite queries must stay parameterized.
-- The SQLite viability baseline is the `modernc.org/sqlite` driver until evidence proves it cannot carry parity.
+- The SQLite viability baseline is the `modernc.org/sqlite` driver until evidence proves it cannot carry the documented product contract.
 - Project-scoped storage must never leak into global storage.
 - Live-data queries must never bypass tombstone guards.
 - Live-data queries must never bypass event-expiry guards: expired events and observations attached to expired events are hidden from normal read surfaces, including direct provenance hydration by ID.
@@ -46,15 +46,9 @@ Fix (calibration protocol):
   6. Split telemetry by `tool_calls.db_scope` before computing the ratio. Global memory uses `MEMORY_HALF_LIFE_WEEKS` (12 by default) and project memory uses `PROJECT_MEMORY_HALF_LIFE_WEEKS` (52 by default), so observations of the same age decay differently across scopes and produce systematically different composite scores. Mixing both scopes into one ratio averages two distributions and pins a threshold that fits neither. The schema already exposes `db_scope`; the obligation is on the analysis path. Same goes for any future per-instance half-life override.
 Done when: either the threshold has been confirmed twice in a row at the same value with the ratio inside [0.5, 0.9], or telemetry has shown a clear reason to redesign the hint (e.g., lexical detection consistently misses semantic conflicts and a pure-Go embedding path becomes available).
 
-- The Go port now replays the shared product fixtures locally, but still lacks an automated Node-vs-Go dual-runtime comparison in CI.
-Trigger: Trusting Go-only fixture replay as full parity proof.
-Blast radius: Drift from the JS reference can sneak in when both sides evolve independently.
-Fix: add a JS-side fixture runner and compare normalized outputs in CI.
-Done when: shared fixtures execute against both runtimes with diffable results.
-
 ### Driver caveats
 
-- The first proven driver is `modernc.org/sqlite`, not the Node reference stack's `better-sqlite3` binding.
+- The proven driver is `modernc.org/sqlite`; CGO-free distribution remains a product constraint.
 - The runtime SQLite/FTS canary runs in CI on macOS, Linux, and Windows. It proves schema init, foreign-key enforcement, contentless FTS insert/match/delete, tombstone persistence, and reopen persistence on each host OS.
 - The store currently forces `SetMaxOpenConns(1)` to keep the early SQLite path deterministic while the persistence layer is still thin.
 - The FTS delete path must keep using the observation-row snapshot of `entity_type`; reading live `entities.entity_type` after mutation is not safe.
@@ -64,18 +58,18 @@ Done when: shared fixtures execute against both runtimes with diffable results.
 
 - None yet.
 
-## Pre-Launch TODO
+## Release proof ledger
 
-- Prove forget semantics including FTS deletion.
-- Prove project isolation.
-- Prove release artifacts for macOS, Linux, and Windows.
-- Prove install flow that is materially simpler than the Node server.
+- [x] Forget semantics including FTS deletion: covered by store tests and the SQLite/FTS runtime canary.
+- [x] Project isolation: covered by project-scoped routing tests and leased `AcquireDB` cache tests.
+- [x] Release artifacts for macOS, Linux, and Windows: covered by CI cross-builds and release workflow artifacts.
+- [x] Install flow on a fresh machine: documented in README and tracked in `IMPLEMENTATION.md` Step 3.3.
 
 ## Error Taxonomy
 
 | Class | Meaning | Mitigation |
 |---|---|---|
-| contract-drift | Go behavior diverges from stable Node semantics | compatibility tests and fixture replay |
+| contract-drift | Behavior diverges from `API_CONTRACT.md`, product fixtures, or documented invariants | compatibility tests and fixture replay |
 | sqlite-feature-gap | chosen driver behaves differently on FTS or migration semantics | canary tests before deeper implementation |
 | project-leak | global and project memory cross-contaminate | path and DB routing tests |
 | ranking-drift | search results are materially reordered | ranking fixtures and deterministic comparisons |

--- a/PITCH.md
+++ b/PITCH.md
@@ -2,22 +2,23 @@
 
 ## One sentence
 
-workmem is the native binary version of mcp-memory: same local-first memory server, same MCP workflow, but distributed as a single executable instead of a Node application with native addons.
+workmem is a local-first MCP memory server distributed as a single native Go
+binary.
 
 ## Problem
 
-The current product pitch is effectively:
+The product promise is:
 
 - zero infrastructure
 - local-first
 - just works
 
-The current installation story weakens that pitch:
+Many local MCP tools weaken that promise with avoidable installation friction:
 
-- requires Node
-- requires `npm install`
+- require a language runtime
+- require package-manager install steps
 - pulls a non-trivial dependency tree
-- relies on native bindings in the current implementation
+- rely on native bindings or environment-specific builds
 - can fail for reasons unrelated to the product itself
 
 For a tool whose whole value proposition is low friction, the install story is part of the product.
@@ -26,13 +27,9 @@ For a tool whose whole value proposition is low friction, the install story is p
 
 The product should feel like its own promise.
 
-A Go binary changes the distribution story from:
+workmem keeps the distribution story simple:
 
-"clone repo, install dependencies, hope your environment likes native builds"
-
-to:
-
-"brew install mcp-memory or download a binary and point your MCP client at it"
+"brew install workmem or download a binary and point your MCP client at it"
 
 That is not a cosmetic improvement. It is product alignment.
 
@@ -52,13 +49,13 @@ Users should get:
 - no runtime prerequisite
 - no dependency install step
 - no infrastructure to manage
-- the same mental model as today
+- a simple MCP memory model that stays local
 
 ## Product bar
 
-This rewrite succeeds only if it is both:
+workmem succeeds only if it is both:
 
-- easier to install than the current server
-- behaviorally trustworthy enough to replace it
+- easy to install on a fresh machine
+- behaviorally trustworthy enough to hold real local memory
 
 If it ships as a pretty binary but drifts on recall, forget semantics, project scoping, or search ranking, it fails.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Some MCP clients (e.g. Kilo, opencode-derivatives) ignore the `env` block in the
 workmem -env-file /path/to/.env
 ```
 
-The parser mirrors the reference Node loader: `KEY=value`, single/double quotes, `# comments`, `export KEY=value`, BOM, CRLF. No variable interpolation, no multi-line, no escape sequences. Missing file is not an error (silent fallback to defaults).
+The parser implements the documented workmem `.env` grammar: `KEY=value`, single/double quotes, `# comments`, `export KEY=value`, BOM, CRLF. No variable interpolation, no multi-line, no escape sequences. Missing file is not an error (silent fallback to defaults).
 
 **Precedence:** explicit process env > `-env-file` values > built-in defaults. A key already present in the environment — even set to an empty string — is never overwritten by the file.
 

--- a/testdata/contracts/README.md
+++ b/testdata/contracts/README.md
@@ -1,16 +1,15 @@
-# Compatibility Contract Fixtures
+# Product Contract Fixtures
 
-These fixtures define the minimum Node-vs-Go comparison surface for the port.
+These fixtures define the minimum externally visible behavior that `workmem`
+must preserve across refactors.
 
 Files:
 
-- `product-contract.json` holds user-visible behavior that must survive the rewrite.
+- `product-contract.json` holds user-visible behavior that must stay stable.
 - `implementation-detail.json` holds lower-level invariants that matter because the product depends on them, even if users never call them directly.
-
-The reference implementation for these fixtures is `marlian/mcp-memory`.
 
 Rules:
 
 - Product contract cases should compare tool inputs and externally visible outcomes.
 - Implementation detail cases should stay small and explicit; they exist to stop silent drift in tombstones, FTS cleanup, and project routing.
-- New parity work should extend these fixtures before adding large amounts of code.
+- New contract-sensitive work should extend these fixtures before adding large amounts of code.


### PR DESCRIPTION
## Summary
- retire Node-vs-Go parity as an active project goal and record Go `workmem` as canonical
- realign OPERATIONS, IMPLEMENTATION, API contract, architecture, pitch, fixtures, and reviewer instructions with the current Go product state
- convert stale pre-launch TODOs into a release proof ledger and add Phase 5 telemetry calibration as the remaining evidence-driven work

## Validation
- `go test ./...`
- rebuilt local Go binary and ran `workmem version`
- rebuilt local Go binary and ran `workmem sqlite-canary`
- `git diff --check`
- VSCode code checker: no issues