### PR TITLE
fix(store): hide empty entity shells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ review/
 thinking/
 docs/internal/
 analysis/
+logs/

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -36,6 +36,13 @@ The Go implementation should preserve the MCP tool surface unless there is a del
   case-insensitive entity-name semantics used by entity lookup, and must not
   mutate the DB.
 - `forget` soft-deletes observations or entities and must remove deleted observations from FTS recall.
+- `list_entities` returns active entities that still carry active context:
+  at least one active observation or at least one live incoming/outgoing
+  relation. Empty shells with no active observations and no live relations are
+  hidden; relation-only entities remain visible.
+- `recall_entity` returns not found for empty shells with no active
+  observations and no live relations. Relation-only entities return a graph
+  with empty observations and their live relations.
 - `project`-scoped calls route to an isolated DB under the target project.
 - provenance tools bypass ranking and return direct facts by identifier, but they must not bypass lifecycle visibility guards such as tombstones or event expiry.
 - `remember_event.expires_at`, when provided, must be a valid timestamp. Expired events and observations attached to expired events are hidden from normal read surfaces: `recall`, `recall_entity`, `recall_events`, `recall_event`, `get_observations`, and `get_event_observations`.

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -1,5 +1,39 @@
 # DECISION LOG
 
+## 2026-05-01: Empty entity shells are hidden, relation-only entities stay visible
+
+### Context
+
+Forgetting individual observations can leave an entity row with zero active
+observations. Showing those rows in `list_entities` pollutes active context and
+makes cleanup look unfinished. A simple "hide all zero-observation entities"
+rule is wrong, though, because `relate` intentionally creates entities whose
+only current value is graph structure.
+
+### Decision
+
+Hide entities with zero active observations and zero live incoming/outgoing
+relations from `list_entities`. `recall_entity` follows the same rule: empty
+shells return not found, while relation-only entities return a graph with empty
+observations and their live relations.
+
+### Rationale
+
+- Empty shells carry no user-visible memory and only add noise.
+- Relation-only entities carry graph context and must remain visible.
+- Applying the same visibility rule to `list_entities` and `recall_entity`
+  avoids a confusing split where list hides an entity but direct recall still
+  resurrects it.
+
+### Alternatives considered
+
+- **Delete empty entities after the last observation is forgotten.** Rejected
+  because entities can become meaningful again through relations, and deletion
+  would make cleanup semantics more destructive.
+- **Keep showing empty shells.** Rejected because it preserves stale context in
+  the default active-entity view.
+- **Add `include_empty`.** Deferred until a real debug/admin workflow needs it.
+
 ## 2026-04-27: Go workmem is canonical; Node parity is retired
 
 ### Context

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -240,8 +240,7 @@ outputs keep private POSIX mode.
 - [x] Return not found from `recall_entity` for empty shells, while preserving
   relation-only entity graphs
 - [x] Add explicit backup output `0600` mode regression coverage
-- [x] Update `API_CONTRACT.md`, `OPERATIONS.md`, `DECISION_LOG.md`, and the
-  historical semantic-hardening spec status
+- [x] Update `API_CONTRACT.md`, `OPERATIONS.md`, and `DECISION_LOG.md`
 
 **On Step Gate (all items [x]):** focused correctness review is sufficient;
 the change is local to entity visibility and backup permission tests.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -203,6 +203,10 @@ failure.
 - [x] Update `API_CONTRACT.md`, `OPERATIONS.md`, and `DECISION_LOG.md`
   with the tightened contract
 
+Note: `thinking/workmem-v1-semantic-hardening-spec.md` also proposed
+zero-observation entity cleanup. That was not part of this Step gate; it was
+closed separately in Step 4.4.
+
 **On Step Gate (all items [x]):** trigger focused correctness/security
 review before release tagging.
 
@@ -222,6 +226,25 @@ canonical architecture.
 - [x] Run the SQLite/FTS runtime canary from the built CLI on macOS, Linux, and Windows CI jobs
 
 **On Step Gate (all items [x]):** focused reviews per PR plus CI matrix proof.
+
+### Step 4.4: Zero-observation entity semantics [✅]
+
+Close the final open item from `thinking/workmem-v1-semantic-hardening-spec.md`.
+**Gate:** `go test ./...` proves empty entity shells are hidden, relation-only
+entities remain visible, `recall_entity` follows the same semantics, and backup
+outputs keep private POSIX mode.
+
+- [x] Hide entities with zero active observations and zero live relations from
+  `list_entities`
+- [x] Keep relation-only entities visible in `list_entities`
+- [x] Return not found from `recall_entity` for empty shells, while preserving
+  relation-only entity graphs
+- [x] Add explicit backup output `0600` mode regression coverage
+- [x] Update `API_CONTRACT.md`, `OPERATIONS.md`, `DECISION_LOG.md`, and the
+  historical semantic-hardening spec status
+
+**On Step Gate (all items [x]):** focused correctness review is sufficient;
+the change is local to entity visibility and backup permission tests.
 
 ## Phase 5: Evidence-driven tuning [🔧]
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -10,6 +10,9 @@
 - Project-scoped storage must never leak into global storage.
 - Live-data queries must never bypass tombstone guards.
 - Live-data queries must never bypass event-expiry guards: expired events and observations attached to expired events are hidden from normal read surfaces, including direct provenance hydration by ID.
+- Entity listing and entity recall must hide empty shells with zero active
+  observations and zero live relations. Relation-only entities remain visible
+  because relations carry graph context.
 - FTS cleanup must never use raw `DELETE` against a contentless FTS table.
 - `remember_event` must be atomic: the event row and all attached observations commit together or not at all. Proof: `TestRememberEventAtomicityOnMidLoopFailure` in `internal/store/parity_test.go`.
 - Telemetry is opt-in (`MEMORY_TELEMETRY_PATH`) and never affects the tool call success path. Init failure logs a single warning to stderr and disables telemetry for the session; the main memory DB is unaffected.
@@ -62,6 +65,8 @@ Done when: either the threshold has been confirmed twice in a row at the same va
 
 - [x] Forget semantics including FTS deletion: covered by store tests and the SQLite/FTS runtime canary.
 - [x] Project isolation: covered by project-scoped routing tests and leased `AcquireDB` cache tests.
+- [x] Zero-observation entity semantics: empty shells hidden and relation-only
+  entities preserved in `list_entities` / `recall_entity` product tests.
 - [x] Release artifacts for macOS, Linux, and Windows: covered by CI cross-builds and release workflow artifacts.
 - [x] Install flow on a fresh machine: documented in README and tracked in `IMPLEMENTATION.md` Step 3.3.
 

--- a/internal/backup/backup_permissions_test.go
+++ b/internal/backup/backup_permissions_test.go
@@ -3,10 +3,13 @@
 package backup
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"filippo.io/age"
 )
 
 // A stat error other than fs.ErrNotExist must surface verbatim — if
@@ -49,5 +52,40 @@ func TestParseRecipientsSurfacesNonNotExistStatError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "stat recipient path") {
 		t.Fatalf("error = %v, want 'stat recipient path' prefix", err)
+	}
+}
+
+func TestRunWritesBackupWithPrivateMode(t *testing.T) {
+	t.Run("new destination", func(t *testing.T) {
+		assertBackupMode(t, false)
+	})
+	t.Run("preexisting loose destination", func(t *testing.T) {
+		assertBackupMode(t, true)
+	})
+}
+
+func assertBackupMode(t *testing.T, preexistingDest bool) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "memory.db")
+	dest := filepath.Join(tmp, "backup.age")
+	seedSourceDB(t, source)
+	if preexistingDest {
+		if err := os.WriteFile(dest, []byte("old loose backup"), 0o644); err != nil {
+			t.Fatalf("write preexisting dest: %v", err)
+		}
+	}
+	identity := newIdentity(t)
+
+	if err := Run(context.Background(), source, dest, []age.Recipient{identity.Recipient()}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("backup mode = %o, want 600", got)
 	}
 }

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -480,6 +480,9 @@ func GetEntityGraph(db *sql.DB, entityName string, halfLifeWeeks float64) (*Enti
 	if err != nil {
 		return nil, err
 	}
+	if len(observations) == 0 && len(outgoing) == 0 && len(incoming) == 0 {
+		return nil, nil
+	}
 
 	return &EntityGraph{
 		Entity:            entity,
@@ -495,22 +498,42 @@ func ListEntities(db *sql.DB, entityType string, limit int) ([]ListedEntity, err
 	}
 	var rows *sql.Rows
 	var err error
+	query := fmt.Sprintf(`
+		WITH observation_counts AS (
+			SELECT o.entity_id, COUNT(o.id) AS observation_count
+			FROM observations o
+			WHERE %s
+			GROUP BY o.entity_id
+		), relation_counts AS (
+			SELECT entity_id, SUM(relation_count) AS relation_count
+			FROM (
+				SELECT r.from_entity_id AS entity_id, COUNT(r.id) AS relation_count
+				FROM relations r
+				JOIN entities src ON src.id = r.from_entity_id AND src.deleted_at IS NULL
+				JOIN entities dst ON dst.id = r.to_entity_id AND dst.deleted_at IS NULL
+				GROUP BY r.from_entity_id
+				UNION ALL
+				SELECT r.to_entity_id AS entity_id, COUNT(r.id) AS relation_count
+				FROM relations r
+				JOIN entities src ON src.id = r.from_entity_id AND src.deleted_at IS NULL
+				JOIN entities dst ON dst.id = r.to_entity_id AND dst.deleted_at IS NULL
+				GROUP BY r.to_entity_id
+			) grouped_relations
+			GROUP BY entity_id
+		)
+		SELECT e.id, e.name, e.entity_type, e.deleted_at, e.created_at, e.updated_at,
+		       COALESCE(oc.observation_count, 0) AS observation_count
+		FROM entities e
+		LEFT JOIN observation_counts oc ON oc.entity_id = e.id
+		LEFT JOIN relation_counts rc ON rc.entity_id = e.id
+		WHERE e.deleted_at IS NULL%s
+		  AND (COALESCE(oc.observation_count, 0) > 0 OR COALESCE(rc.relation_count, 0) > 0)
+		ORDER BY e.updated_at DESC LIMIT ?
+	`, activeObservationSQL("o"), nullableEntityTypeFilter(entityType))
 	if entityType != "" {
-		rows, err = db.Query(fmt.Sprintf(`
-			SELECT e.id, e.name, e.entity_type, e.deleted_at, e.created_at, e.updated_at, COUNT(o.id) AS observation_count
-			FROM entities e
-			LEFT JOIN observations o ON o.entity_id = e.id AND %s
-			WHERE e.deleted_at IS NULL AND e.entity_type = ?
-			GROUP BY e.id ORDER BY e.updated_at DESC LIMIT ?
-		`, activeObservationSQL("o")), entityType, limit)
+		rows, err = db.Query(query, entityType, limit)
 	} else {
-		rows, err = db.Query(fmt.Sprintf(`
-			SELECT e.id, e.name, e.entity_type, e.deleted_at, e.created_at, e.updated_at, COUNT(o.id) AS observation_count
-			FROM entities e
-			LEFT JOIN observations o ON o.entity_id = e.id AND %s
-			WHERE e.deleted_at IS NULL
-			GROUP BY e.id ORDER BY e.updated_at DESC LIMIT ?
-		`, activeObservationSQL("o")), limit)
+		rows, err = db.Query(query, limit)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list entities: %w", err)
@@ -533,6 +556,13 @@ func ListEntities(db *sql.DB, entityType string, limit int) ([]ListedEntity, err
 		return nil, fmt.Errorf("iterate listed entities: %w", err)
 	}
 	return results, nil
+}
+
+func nullableEntityTypeFilter(entityType string) string {
+	if entityType == "" {
+		return ""
+	}
+	return " AND e.entity_type = ?"
 }
 
 func getEventByID(db *sql.DB, eventID int64) (*EventRecord, error) {

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -22,6 +22,15 @@ func newTestDB(t *testing.T, name string) *sql.DB {
 	return db
 }
 
+func listedEntityByName(listed []ListedEntity, name string) (ListedEntity, bool) {
+	for _, entity := range listed {
+		if entity.Name == name {
+			return entity, true
+		}
+	}
+	return ListedEntity{}, false
+}
+
 func TestCoreMemoryParity(t *testing.T) {
 	db := newTestDB(t, "core.db")
 
@@ -74,6 +83,92 @@ func TestCoreMemoryParity(t *testing.T) {
 			if item.ID == observationID {
 				t.Fatalf("deleted observation still appears in recall")
 			}
+		}
+	})
+
+	t.Run("zero observation entities stay hidden unless relation-only", func(t *testing.T) {
+		if _, err := UpsertEntity(db, "EmptyShellEntity", "test"); err != nil {
+			t.Fatalf("UpsertEntity(empty shell) error = %v", err)
+		}
+		listed, err := ListEntities(db, "", 50)
+		if err != nil {
+			t.Fatalf("ListEntities(empty shell) error = %v", err)
+		}
+		if _, ok := listedEntityByName(listed, "EmptyShellEntity"); ok {
+			t.Fatalf("empty shell appears in ListEntities")
+		}
+		graph, err := GetEntityGraph(db, "EmptyShellEntity", 12)
+		if err != nil {
+			t.Fatalf("GetEntityGraph(empty shell) error = %v", err)
+		}
+		if graph != nil {
+			t.Fatalf("empty shell appears in GetEntityGraph: %#v", graph)
+		}
+
+		forgottenID, err := UpsertEntity(db, "ForgottenLastObservationEntity", "test")
+		if err != nil {
+			t.Fatalf("UpsertEntity(forgotten last observation) error = %v", err)
+		}
+		observationID, err := AddObservation(db, forgottenID, "last observation to forget", "user", 1.0)
+		if err != nil {
+			t.Fatalf("AddObservation(last observation) error = %v", err)
+		}
+		listed, err = ListEntities(db, "", 50)
+		if err != nil {
+			t.Fatalf("ListEntities(with observation) error = %v", err)
+		}
+		if _, ok := listedEntityByName(listed, "ForgottenLastObservationEntity"); !ok {
+			t.Fatalf("entity with an active observation missing from ListEntities")
+		}
+		if _, err := HandleTool(db, "forget", ToolArgs{ObservationID: &observationID}); err != nil {
+			t.Fatalf("HandleTool(forget last observation) error = %v", err)
+		}
+		listed, err = ListEntities(db, "", 50)
+		if err != nil {
+			t.Fatalf("ListEntities(after last observation forget) error = %v", err)
+		}
+		if _, ok := listedEntityByName(listed, "ForgottenLastObservationEntity"); ok {
+			t.Fatalf("entity with no active observations or relations appears in ListEntities")
+		}
+		graph, err = GetEntityGraph(db, "ForgottenLastObservationEntity", 12)
+		if err != nil {
+			t.Fatalf("GetEntityGraph(after last observation forget) error = %v", err)
+		}
+		if graph != nil {
+			t.Fatalf("entity with no active observations or relations appears in GetEntityGraph: %#v", graph)
+		}
+
+		if _, err := HandleTool(db, "relate", ToolArgs{From: "RelationOnlySource", To: "RelationOnlyTarget", RelationType: "depends_on"}); err != nil {
+			t.Fatalf("HandleTool(relation-only relate) error = %v", err)
+		}
+		listed, err = ListEntities(db, "", 50)
+		if err != nil {
+			t.Fatalf("ListEntities(relation-only) error = %v", err)
+		}
+		if source, ok := listedEntityByName(listed, "RelationOnlySource"); !ok {
+			t.Fatalf("relation-only source missing from ListEntities")
+		} else if source.ObservationCount != 0 {
+			t.Fatalf("relation-only source observation_count = %d, want 0", source.ObservationCount)
+		}
+		if target, ok := listedEntityByName(listed, "RelationOnlyTarget"); !ok {
+			t.Fatalf("relation-only target missing from ListEntities")
+		} else if target.ObservationCount != 0 {
+			t.Fatalf("relation-only target observation_count = %d, want 0", target.ObservationCount)
+		}
+
+		sourceGraph, err := GetEntityGraph(db, "RelationOnlySource", 12)
+		if err != nil {
+			t.Fatalf("GetEntityGraph(relation-only source) error = %v", err)
+		}
+		if sourceGraph == nil || len(sourceGraph.Observations) != 0 || len(sourceGraph.RelationsOutgoing) != 1 || len(sourceGraph.RelationsIncoming) != 0 {
+			t.Fatalf("relation-only source graph = %#v, want one outgoing relation and no observations", sourceGraph)
+		}
+		targetGraph, err := GetEntityGraph(db, "RelationOnlyTarget", 12)
+		if err != nil {
+			t.Fatalf("GetEntityGraph(relation-only target) error = %v", err)
+		}
+		if targetGraph == nil || len(targetGraph.Observations) != 0 || len(targetGraph.RelationsIncoming) != 1 || len(targetGraph.RelationsOutgoing) != 0 {
+			t.Fatalf("relation-only target graph = %#v, want one incoming relation and no observations", targetGraph)
 		}
 	})
 
@@ -459,11 +554,8 @@ func TestEventsAndProvenanceParity(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetEntityGraph(expired) error = %v", err)
 		}
-		if expiredGraph == nil {
-			t.Fatalf("GetEntityGraph(expired) returned nil entity graph; want entity with hidden observations")
-		}
-		if len(expiredGraph.Observations) != 0 {
-			t.Fatalf("GetEntityGraph returned expired observations: %#v", expiredGraph.Observations)
+		if expiredGraph != nil {
+			t.Fatalf("GetEntityGraph returned entity whose only observation is expired: %#v", expiredGraph)
 		}
 
 		futureRecall, _, err := SearchMemory(db, "futureonlytoken", 10, 12)


### PR DESCRIPTION
## Summary
- Hide zero-observation entity shells from `list_entities` and `recall_entity` while preserving relation-only entity graphs.
- Add regression coverage for zero-observation semantics and backup output `0600` permissions.
- Update API/operations/implementation/decision docs and ignore local `logs/`.

## Validation
- `go test ./...`