### PR TITLE
feat(store): add reconcile supersession plumbing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,15 +31,17 @@ testdata/contracts/          — shared behavioral fixtures
 
 ## Database schema
 
-Five ordinary tables plus the contentless FTS table. Soft-delete via `deleted_at TEXT` applies only to `entities` and `observations`:
+Seven ordinary tables plus the contentless FTS table. Soft-delete via `deleted_at TEXT` applies only to `entities` and `observations`:
 
 - `entities` — named objects (`name UNIQUE COLLATE NOCASE`, `entity_type`, `deleted_at`, timestamps)
-- `observations` — atomic facts linked to an entity (`entity_id`, `content`, `source`, `confidence`, `access_count`, `last_accessed`, `deleted_at`, `event_id`, `entity_type` snapshot, timestamps)
+- `observations` — atomic facts linked to an entity (`entity_id`, `content`, `source`, `confidence`, `access_count`, `last_accessed`, `deleted_at`, `superseded_by`, `event_id`, `entity_type` snapshot, timestamps)
 - `relations` — typed edges between entities — **no soft-delete**, hard-deleted when entity is tombstoned
 - `events` — grouped sessions/meetings/decisions (`label`, `event_date`, `event_type`, `context`, `expires_at`) — **no soft-delete**
+- `reconcile_runs` — audit records for slow memory hygiene runs
+- `reconcile_decisions` — reversible decisions proposed/applied by reconcile runs
 - `schema_migrations` — version registry for schema upgrades (`version`, `applied_at`)
 
-**Invariant:** every query that reads live data **must** have `deleted_at IS NULL` guards on both `entities` and `observations`. Missing this guard is a tombstone bypass bug.
+**Invariant:** every query that reads live data **must** guard entity tombstones, observation tombstones, and observation supersession (`superseded_by IS NULL`). Missing any guard is a lifecycle bypass bug.
 
 ## FTS5 — contentless table
 
@@ -95,7 +97,7 @@ Every tool must:
 
 - `go test ./...` must pass on all changes
 - Each test creates an isolated DB via `t.TempDir()`
-- Test tombstone paths (deleted entities/observations excluded)
+- Test lifecycle paths (deleted/superseded observations and deleted entities excluded)
 - Test FTS paths (forget removes from subsequent recall)
 - `testdata/contracts/` contains shared behavioral fixtures
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,7 +41,7 @@ Seven ordinary tables plus the contentless FTS table. Soft-delete via `deleted_a
 - `reconcile_decisions` — reversible decisions proposed/applied by reconcile runs
 - `schema_migrations` — version registry for schema upgrades (`version`, `applied_at`)
 
-**Invariant:** every query that reads live data **must** guard entity tombstones, observation tombstones, and observation supersession (`superseded_by IS NULL`). Missing any guard is a lifecycle bypass bug.
+**Invariant:** every query that reads live data **must** guard entity tombstones, observation tombstones, observation supersession (`superseded_by IS NULL`), and event expiry (`events.expires_at`). Missing any guard is a lifecycle bypass bug.
 
 ## FTS5 — contentless table
 
@@ -97,7 +97,7 @@ Every tool must:
 
 - `go test ./...` must pass on all changes
 - Each test creates an isolated DB via `t.TempDir()`
-- Test lifecycle paths (deleted/superseded observations and deleted entities excluded)
+- Test lifecycle paths (deleted/superseded observations, deleted entities, and expired events/event observations excluded)
 - Test FTS paths (forget removes from subsequent recall)
 - `testdata/contracts/` contains shared behavioral fixtures
 

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -74,7 +74,8 @@ If a PR touches `SearchMemory`, `CollectCandidates`, `HydrateCandidates`, or `Sc
 
 - New tools or changed behavior must have tests
 - Tests use `t.TempDir()` for isolation — never production DBs
-- Test tombstone exclusion for affected paths
+- Test lifecycle exclusion for affected paths: tombstoned entities/observations
+  and superseded observations must not appear as active memory
 - Test FTS cleanup after forget
 
 ## Telemetry design rationale (do NOT flag)

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -74,7 +74,7 @@ If a PR touches `SearchMemory`, `CollectCandidates`, `HydrateCandidates`, or `Sc
 
 - New tools or changed behavior must have tests
 - Tests use `t.TempDir()` for isolation — never production DBs
-- Test lifecycle exclusion for affected paths: tombstoned entities/observations
+- Test lifecycle exclusion for affected paths: tombstoned entities/observations,
   superseded observations, and expired event observations must not appear as
   active memory
 - Test FTS cleanup after forget

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -75,7 +75,8 @@ If a PR touches `SearchMemory`, `CollectCandidates`, `HydrateCandidates`, or `Sc
 - New tools or changed behavior must have tests
 - Tests use `t.TempDir()` for isolation — never production DBs
 - Test lifecycle exclusion for affected paths: tombstoned entities/observations
-  and superseded observations must not appear as active memory
+  superseded observations, and expired event observations must not appear as
+  active memory
 - Test FTS cleanup after forget
 
 ## Telemetry design rationale (do NOT flag)

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -44,7 +44,11 @@ The Go implementation should preserve the MCP tool surface unless there is a del
   observations and no live relations. Relation-only entities return a graph
   with empty observations and their live relations.
 - `project`-scoped calls route to an isolated DB under the target project.
-- provenance tools bypass ranking and return direct facts by identifier, but they must not bypass lifecycle visibility guards such as tombstones or event expiry.
+- provenance tools bypass ranking and return direct facts by identifier, but they must not bypass lifecycle visibility guards such as tombstones, supersession, or event expiry.
+- Superseded observations are hidden from normal active-memory read surfaces:
+  `recall`, `recall_entity`, `list_entities` active observation counts,
+  `recall_events` observation counts, `recall_event`, `get_observations`, and
+  `get_event_observations`.
 - `remember_event.expires_at`, when provided, must be a valid timestamp. Expired events and observations attached to expired events are hidden from normal read surfaces: `recall`, `recall_entity`, `recall_events`, `recall_event`, `get_observations`, and `get_event_observations`.
 
 ## Compatibility policy
@@ -87,9 +91,9 @@ about a new field must keep working unchanged.
 
 Motivated by the 2026-04-22 decision (`DECISION_LOG.md`). When
 `remember` stores an observation on an entity, the backend runs the
-composite ranker scoped to that entity's non-deleted observations and,
-if any score above a conservative similarity threshold, surfaces up to
-3 of them on the response:
+composite ranker scoped to that entity's active observations and, if any score
+above a conservative similarity threshold, surfaces up to 3 of them on the
+response:
 
 ```json
 {
@@ -108,14 +112,19 @@ Contract properties:
   qualifying conflicts. Clients that ignore the field must keep
   working identically to the pre-extension response.
 - The field is a **hint**, not a command. The backend never
-  soft-deletes on the agent's behalf. Supersession is the agent's
-  decision, performed via `forget(observation_id)`.
+  soft-deletes or supersedes on the agent's behalf. `forget(observation_id)`
+  remains a deletion/privacy-erasure path. Reversible supersession is reserved
+  for the reconcile audit flow.
 - The similarity score is a lexical signal derived from the existing
   composite ranker. It is not a semantic contradiction score and must
   not be documented as such.
 - `forget` semantics are unchanged. Adding `possible_conflicts`
   extends `remember` only; nothing in the "not allowed to drift early"
   list moves.
+- Superseded observations are not active observations and are not candidates for
+  `possible_conflicts`. A later identical write can create a new active
+  observation; deterministic reconcile is responsible for cleaning that up once
+  the runner exists.
 - The similarity threshold is provisional at launch and calibrated via
   telemetry (`conflicts_surfaced` vs `conflicts_acted_on`). Threshold
   changes are implementation-internal and do not constitute a contract

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -49,6 +49,10 @@ The Go implementation should preserve the MCP tool surface unless there is a del
   `recall`, `recall_entity`, `list_entities` active observation counts,
   `recall_events` observation counts, `recall_event`, `get_observations`, and
   `get_event_observations`.
+- Supersession is explicit lifecycle state, not a conditional alias. A
+  superseded observation stays hidden until rollback/repair clears its
+  supersession marker; it is not automatically resurrected if the replacement
+  observation later becomes inactive.
 - `remember_event.expires_at`, when provided, must be a valid timestamp. Expired events and observations attached to expired events are hidden from normal read surfaces: `recall`, `recall_entity`, `recall_events`, `recall_event`, `get_observations`, and `get_event_observations`.
 
 ## Compatibility policy

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -66,13 +66,20 @@ Responsible for:
 
 ## Key invariants to preserve
 
-### Tombstone discipline
+### Lifecycle visibility discipline
 
-Queries returning live memory must exclude soft-deleted entities and observations.
+Queries returning live memory must exclude soft-deleted entities, soft-deleted
+observations, superseded observations, and observations attached to expired
+events. Provenance tools may bypass ranking, but not lifecycle visibility
+guards.
 
 ### FTS delete correctness
 
 The contentless FTS table requires the SQLite special delete insert pattern. The delete path must match the originally indexed data.
+
+Supersession does not require immediate FTS row deletion; FTS-backed reads must
+join through the active-observation predicate so superseded rows stay hidden.
+Tombstone/forget cleanup remains the path that physically removes FTS rows.
 
 ### Project isolation
 

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -31,6 +31,10 @@ post-v0.
 - Supersession leaves contentless FTS rows in place and relies on the active
   observation join predicate for visibility. That keeps rollback simple; physical
   FTS cleanup remains tied to tombstones.
+- A superseded source does not automatically reappear if its replacement later
+  becomes inactive. Resurrecting old memory because a target was forgotten or
+  expired would make deletion/expiry semantics surprising; recovery must be an
+  explicit rollback/repair action that clears supersession.
 - The PR1 schema is substrate only. Before any production writer sets
   supersession, Step 6.3 must validate no self-supersession, active source/target
   observations, same-entity exact duplicates, JSON-array `source_obs_ids`, and a

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -1,5 +1,50 @@
 # DECISION LOG
 
+## 2026-05-02: Reconcile v0 starts with deterministic supersession plumbing
+
+### Context
+
+Telemetry showed that agents receive conflict hints but do not act on them.
+Moving all cleanup into the hot `remember` path would risk latency, privacy, and
+API churn. The safer shape is a slow reconcile layer, but semantic embeddings
+and summarization are too risky as a first mutation surface.
+
+### Decision
+
+Start reconcile v0 with additive supersession plumbing only: observation
+supersession columns, reconcile run/decision audit tables, and read-path filters
+that hide superseded observations from active memory. The first runnable
+reconcile CLI will be deterministic-first; embeddings and summarization remain
+post-v0.
+
+### Rationale
+
+- Supersession must become a lifecycle guard like tombstones and event expiry
+  before any runner can safely apply decisions.
+- Additive schema changes let current hot-path tools keep their response shapes.
+- Exact duplicate apply/rollback is a small, reversible proof of the audit loop.
+- Local-first semantic embeddings can come later without changing the core
+  visibility contract.
+- `forget` remains deletion/privacy erasure. It may still tombstone an already
+  superseded observation if called by ID, but reversible supersession is an
+  audited reconcile decision, not `forget` by another name.
+- Supersession leaves contentless FTS rows in place and relies on the active
+  observation join predicate for visibility. That keeps rollback simple; physical
+  FTS cleanup remains tied to tombstones.
+- The PR1 schema is substrate only. Before any production writer sets
+  supersession, Step 6.3 must validate no self-supersession, active source/target
+  observations, same-entity exact duplicates, JSON-array `source_obs_ids`, and a
+  reconcile run attached to every applied decision.
+
+### Alternatives considered
+
+- **Start with embeddings.** Rejected. It mixes provider/privacy risk with the
+  first schema/read-path change.
+- **Add summarization in v0.** Rejected. Generated summaries becoming memory is
+  a higher-risk operation that needs real report telemetry first.
+- **Keep conflict hints as the only cleanup mechanism.** Rejected. Current
+  telemetry showed a 0% acted-on rate.
+
 ## 2026-05-01: Empty entity shells are hidden, relation-only entities stay visible
 
 ### Context

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -134,8 +134,8 @@ observable.
 ### Step 4.1: Conflict hints in `remember` response [✅]
 
 Surface same-entity near-duplicate observations when the agent calls
-`remember`, so supersession-as-forget becomes observable from the
-agent's point of view. Full rationale and telemetry evidence
+`remember`, so possible conflicts become observable from the agent's point of
+view. Full rationale and telemetry evidence
 (14/14 silent overwrites in the first 8 days of production data) in
 `DECISION_LOG.md` under 2026-04-22.
 
@@ -143,8 +143,7 @@ agent's point of view. Full rationale and telemetry evidence
 high-similarity writes; telemetry records `conflicts_surfaced` per
 `remember` call and `conflicts_acted_on` is derivable post-hoc from
 `forget` calls against surfaced observation IDs; an integration
-fixture demonstrates the end-to-end loop (write → hint → forget →
-clean recall).
+fixture demonstrates the deletion loop (write → hint → forget → clean recall).
 
 - [x] Implement scoped composite-ranker conflict detection in the
   Remember path (reuse ranking logic from `internal/store/search.go`,
@@ -263,3 +262,50 @@ or records an evidence-backed adjustment in `DECISION_LOG.md`.
 
 **On Step Gate (all items [x]):** correctness review focused on threshold
 evidence and false-positive/false-negative trade-offs.
+
+## Phase 6: Reconcile runner v0 [🔧]
+
+Add a slow, audit-first memory hygiene layer without changing the hot MCP tool
+surface. v0 is deterministic-first: no embeddings, no remote providers, no
+summarization-as-truth.
+
+### Step 6.1: Supersession plumbing [✅]
+
+Create the substrate that later reconcile runs can use safely. **Gate:** all
+normal active-memory read paths hide superseded observations, migrations upgrade
+legacy DBs, and no reconcile CLI exists yet.
+
+- [x] Add migration-tracked observation supersession columns
+- [x] Add reconcile run/decision audit tables and indexes
+- [x] Filter `superseded_by IS NOT NULL` observations from recall, entity/event
+  recall, provenance hydration, active counts, FTS ID search, and conflict hints
+- [x] Cover fresh schema, legacy migrations, and read-path discipline in tests
+- [x] Update `API_CONTRACT.md`, `OPERATIONS.md`, `ARCHITECTURE.md`,
+  `DECISION_LOG.md`, README guidance, and GitHub review instructions
+
+**On Step Gate (all items [x]):** focused correctness review before building
+the reconcile CLI.
+
+### Step 6.2: Deterministic propose report [⏸]
+
+Implement `workmem reconcile` in propose mode only. **Gate:** exact duplicate
+candidates are reported in markdown with no memory mutations.
+
+- [ ] Add `workmem reconcile --mode propose`
+- [ ] Detect exact duplicate observations within the same entity
+- [ ] Write markdown report under ignored `review/`
+- [ ] Support global and project scopes
+
+### Step 6.3: Exact duplicate apply and rollback [⏸]
+
+Apply only deterministic exact duplicate supersession. **Gate:** rollback fully
+restores active visibility and audit rows show what changed.
+
+- [ ] Apply exact duplicate supersession in a short transaction
+- [ ] Record complete reconcile decisions
+- [ ] Validate applied decisions before mutation: no self-supersession, active
+  source/target observations, source/target same entity for exact duplicates,
+  `source_obs_ids` encoded as a JSON array, and every applied supersession tied
+  to a reconcile run
+- [ ] Add `workmem reconcile rollback <run_id>`
+- [ ] Prove rollback restores read-path visibility

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -9,11 +9,18 @@
 - The SQLite viability baseline is the `modernc.org/sqlite` driver until evidence proves it cannot carry the documented product contract.
 - Project-scoped storage must never leak into global storage.
 - Live-data queries must never bypass tombstone guards.
+- Live-data queries must never bypass supersession guards: observations with
+  `superseded_by IS NOT NULL` are not active memory and must be hidden from
+  recall, entity/event recall, direct observation hydration, and active counts.
 - Live-data queries must never bypass event-expiry guards: expired events and observations attached to expired events are hidden from normal read surfaces, including direct provenance hydration by ID.
 - Entity listing and entity recall must hide empty shells with zero active
   observations and zero live relations. Relation-only entities remain visible
   because relations carry graph context.
 - FTS cleanup must never use raw `DELETE` against a contentless FTS table.
+- Supersession hides observations from FTS-backed reads through the active
+  observation join predicate. Supersession does not physically delete FTS rows;
+  tombstone/forget remains the FTS cleanup path so rollback can restore
+  superseded observations without FTS rehydration.
 - `remember_event` must be atomic: the event row and all attached observations commit together or not at all. Proof: `TestRememberEventAtomicityOnMidLoopFailure` in `internal/store/parity_test.go`.
 - Telemetry is opt-in (`MEMORY_TELEMETRY_PATH`) and never affects the tool call success path. Init failure logs a single warning to stderr and disables telemetry for the session; the main memory DB is unaffected.
 - Telemetry data lives in its own SQLite file, physically separate from the memory database. No foreign keys, no joins, no shared lifecycle.
@@ -59,7 +66,18 @@ Done when: either the threshold has been confirmed twice in a row at the same va
 
 ### P2
 
-- None yet.
+- Until `workmem reconcile --mode apply` exists, superseded observations are
+  hidden but cannot be produced by a first-class write path. Exact content
+  matching a superseded observation can be remembered again as a new active
+  observation; Step 6.3 will clean deterministic duplicates through audited
+  supersession.
+Trigger: a user or future migration manually marks observations superseded, then
+the same content is remembered again before the runner exists.
+Blast radius: harmless duplicate active observations that the future deterministic
+reconcile step must collapse.
+Fix: implement Step 6.2/6.3 exact duplicate propose/apply and consider conflict
+hints against superseded history only if real reports show this matters.
+Done when: exact duplicate reconcile apply/rollback is shipped and tested.
 
 ## Release proof ledger
 
@@ -67,6 +85,9 @@ Done when: either the threshold has been confirmed twice in a row at the same va
 - [x] Project isolation: covered by project-scoped routing tests and leased `AcquireDB` cache tests.
 - [x] Zero-observation entity semantics: empty shells hidden and relation-only
   entities preserved in `list_entities` / `recall_entity` product tests.
+- [x] Supersession lifecycle guard: superseded observations hidden from recall,
+  entity/event recall, provenance hydration, active counts, FTS ID search, and
+  conflict hints.
 - [x] Release artifacts for macOS, Linux, and Windows: covered by CI cross-builds and release workflow artifacts.
 - [x] Install flow on a fresh machine: documented in README and tracked in `IMPLEMENTATION.md` Step 3.3.
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -12,6 +12,9 @@
 - Live-data queries must never bypass supersession guards: observations with
   `superseded_by IS NOT NULL` are not active memory and must be hidden from
   recall, entity/event recall, direct observation hydration, and active counts.
+- Supersession never auto-resurrects sources when the replacement observation
+  becomes inactive. Recovery is an explicit rollback/repair operation that
+  clears the supersession marker.
 - Live-data queries must never bypass event-expiry guards: expired events and observations attached to expired events are hidden from normal read surfaces, including direct provenance hydration by ID.
 - Entity listing and entity recall must hide empty shells with zero active
   observations and zero live relations. Relation-only entities remain visible

--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ You have access to a persistent memory store. Use it proactively:
 
 If `remember` returns `possible_conflicts`, review those observations before
 storing more related facts. Use `forget(obs_id)` only when the old fact should
-be deleted/erased; reversible supersession is handled by the reconcile flow.
+be deleted/erased. Reversible supersession is planned for the reconcile flow;
+until that command exists, do not edit the database manually to simulate it.
 
 Remember: preferences, corrections, names, decisions, conventions.
 Don't remember: transient tasks, code snippets, things already in docs/git.

--- a/README.md
+++ b/README.md
@@ -245,8 +245,9 @@ You have access to a persistent memory store. Use it proactively:
 - **`forget`** to remove stale or incorrect facts
 - **`relate`** to link entities with named relationships
 
-If `remember` returns `possible_conflicts`, review those observations
-and call `forget(obs_id)` on any your new fact supersedes.
+If `remember` returns `possible_conflicts`, review those observations before
+storing more related facts. Use `forget(obs_id)` only when the old fact should
+be deleted/erased; reversible supersession is handled by the reconcile flow.
 
 Remember: preferences, corrections, names, decisions, conventions.
 Don't remember: transient tasks, code snippets, things already in docs/git.
@@ -254,7 +255,7 @@ Don't remember: transient tasks, code snippets, things already in docs/git.
 
 ## Database
 
-SQLite with WAL mode. Tables: `entities`, `observations`, `relations`, `events`, `memory_fts` (FTS5). Schema created automatically. Soft-delete via `deleted_at` tombstones — forgotten facts are excluded from retrieval but remain in the database.
+SQLite with WAL mode. Tables include `entities`, `observations`, `relations`, `events`, reconcile audit tables, and `memory_fts` (FTS5). Schema created automatically. Soft-delete via `deleted_at` tombstones — forgotten facts are excluded from retrieval but remain in the database. Superseded observations are also excluded from active-memory reads while preserving auditability.
 
 ## Backup
 

--- a/internal/store/conflict.go
+++ b/internal/store/conflict.go
@@ -7,8 +7,10 @@ import (
 
 // ConflictHint describes an existing observation on the same entity whose
 // lexical similarity to a new content exceeds the conflict threshold.
-// Surfaced on `remember` responses so the agent can decide whether to
-// `forget` the prior fact. See DECISION_LOG 2026-04-22.
+// Surfaced on `remember` responses as a review hint, not as an instruction to
+// mutate memory. Deletion still goes through `forget`; reversible supersession
+// belongs to the reconcile audit flow. See DECISION_LOG 2026-04-22 and
+// 2026-05-02.
 type ConflictHint struct {
 	ObservationID int64   `json:"observation_id"`
 	Similarity    float64 `json:"similarity"`

--- a/internal/store/conflict_test.go
+++ b/internal/store/conflict_test.go
@@ -128,6 +128,35 @@ func TestDetectEntityConflicts_IgnoresTombstonedObservations(t *testing.T) {
 	}
 }
 
+func TestDetectEntityConflicts_IgnoresSupersededObservations(t *testing.T) {
+	t.Parallel()
+	db := newConflictTestDB(t)
+
+	entityID, err := UpsertEntity(db, "API", "")
+	if err != nil {
+		t.Fatalf("UpsertEntity: %v", err)
+	}
+	priorID, err := AddObservation(db, entityID, "rate limit is 100 per minute", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(prior): %v", err)
+	}
+	targetID, err := AddObservation(db, entityID, "canonical rate limit is 200 per minute", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(target): %v", err)
+	}
+	markObservationSupersededForTest(t, db, priorID, targetID, "test_supersession")
+
+	hints, err := DetectEntityConflicts(db, entityID, "rate limit is 100 per minute", memoryHalfLifeWeeks())
+	if err != nil {
+		t.Fatalf("DetectEntityConflicts: %v", err)
+	}
+	for _, hint := range hints {
+		if hint.ObservationID == priorID {
+			t.Fatalf("superseded observation surfaced as conflict hint: %+v", hint)
+		}
+	}
+}
+
 func TestDetectEntityConflicts_IgnoresTombstonedEntityDrift(t *testing.T) {
 	t.Parallel()
 	db := newConflictTestDB(t)

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -14,12 +14,12 @@ func activeEventSQL(alias string) string {
 }
 
 func activeObservationSQL(alias string) string {
-	return fmt.Sprintf(`%s.deleted_at IS NULL AND (
+	return fmt.Sprintf(`%s.deleted_at IS NULL AND %s.superseded_by IS NULL AND (
 		%s.event_id IS NULL OR EXISTS (
 			SELECT 1 FROM events ev_active
 			WHERE ev_active.id = %s.event_id AND %s
 		)
-	)`, alias, alias, alias, activeEventSQL("ev_active"))
+	)`, alias, alias, alias, alias, activeEventSQL("ev_active"))
 }
 
 func normalizeExpiresAt(value string) (any, error) {

--- a/internal/store/events_test.go
+++ b/internal/store/events_test.go
@@ -50,6 +50,45 @@ func TestSearchEventsCountsObservationsCorrectly(t *testing.T) {
 	}
 }
 
+func TestSearchEventsIgnoresSupersededObservationsInCounts(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "events-superseded-count.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	eventID, err := CreateEvent(db, "Superseded count event", "2026-04-26", "meeting", "", "")
+	if err != nil {
+		t.Fatalf("CreateEvent() error = %v", err)
+	}
+	entityID, err := UpsertEntity(db, "SupersededCountEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	sourceID, err := AddObservation(db, entityID, "old count value", "user", 1.0, eventID)
+	if err != nil {
+		t.Fatalf("AddObservation(source) error = %v", err)
+	}
+	targetID, err := AddObservation(db, entityID, "new count value", "user", 1.0, eventID)
+	if err != nil {
+		t.Fatalf("AddObservation(target) error = %v", err)
+	}
+	markObservationSupersededForTest(t, db, sourceID, targetID, "test_supersession")
+
+	results, err := SearchEvents(db, "Superseded count event", "", "", "", 10)
+	if err != nil {
+		t.Fatalf("SearchEvents() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("SearchEvents() returned %d results, want 1", len(results))
+	}
+	if results[0].ObservationCount != 1 {
+		t.Fatalf("SearchEvents() ObservationCount = %d, want 1", results[0].ObservationCount)
+	}
+}
+
 func TestSearchEventsEscapesLikeWildcards(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -738,6 +738,38 @@ func TestEventsAndProvenanceParity(t *testing.T) {
 		}
 	})
 
+	t.Run("superseded observations do not satisfy duplicate writes", func(t *testing.T) {
+		entityID, err := UpsertEntity(db, "SupersededDuplicateEntity", "test")
+		if err != nil {
+			t.Fatalf("UpsertEntity() error = %v", err)
+		}
+		sourceID, err := AddObservation(db, entityID, "duplicatesupersededtoken", "user", 1.0)
+		if err != nil {
+			t.Fatalf("AddObservation(source) error = %v", err)
+		}
+		targetID, err := AddObservation(db, entityID, "canonical replacement for duplicate superseded token", "user", 1.0)
+		if err != nil {
+			t.Fatalf("AddObservation(target) error = %v", err)
+		}
+		markObservationSupersededForTest(t, db, sourceID, targetID, "test_supersession")
+
+		newObservationID, err := AddObservation(db, entityID, "duplicatesupersededtoken", "user", 1.0)
+		if err != nil {
+			t.Fatalf("AddObservation(non-superseded duplicate) error = %v", err)
+		}
+		if newObservationID == sourceID {
+			t.Fatalf("AddObservation reused superseded observation id %d", sourceID)
+		}
+
+		results, _, err := SearchMemory(db, "duplicatesupersededtoken", 10, 12)
+		if err != nil {
+			t.Fatalf("SearchMemory() error = %v", err)
+		}
+		if len(results) != 1 || results[0].ID != newObservationID {
+			t.Fatalf("SearchMemory() = %#v, want only new observation %d", results, newObservationID)
+		}
+	})
+
 	t.Run("get observations preserves order and skips tombstones", func(t *testing.T) {
 		entityID, err := UpsertEntity(db, "OrderedEntity", "test")
 		if err != nil {

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -31,6 +31,31 @@ func listedEntityByName(listed []ListedEntity, name string) (ListedEntity, bool)
 	return ListedEntity{}, false
 }
 
+func markObservationSupersededForTest(t *testing.T, db *sql.DB, sourceID, targetID int64, reason string) {
+	t.Helper()
+	if reason == "" {
+		reason = "test_supersession"
+	}
+	result, err := db.Exec(
+		`UPDATE observations
+		 SET superseded_by = ?, superseded_at = CURRENT_TIMESTAMP, superseded_reason = ?
+		 WHERE id = ? AND deleted_at IS NULL`,
+		targetID,
+		reason,
+		sourceID,
+	)
+	if err != nil {
+		t.Fatalf("mark observation superseded: %v", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		t.Fatalf("mark observation superseded rows affected: %v", err)
+	}
+	if rowsAffected != 1 {
+		t.Fatalf("mark observation superseded rows affected = %d, want 1", rowsAffected)
+	}
+}
+
 func TestCoreMemoryParity(t *testing.T) {
 	db := newTestDB(t, "core.db")
 
@@ -427,6 +452,90 @@ func TestEventsAndProvenanceParity(t *testing.T) {
 		}
 		if len(events) == 0 || events[0].ObservationCount != 0 {
 			t.Fatalf("deleted event observation still counted in search events")
+		}
+	})
+
+	t.Run("superseded observations disappear from normal read surfaces", func(t *testing.T) {
+		entityID, err := UpsertEntity(db, "SupersededSurfaceEntity", "test")
+		if err != nil {
+			t.Fatalf("UpsertEntity() error = %v", err)
+		}
+		eventID, err := CreateEvent(db, "Superseded visibility event", "", "test", "", "")
+		if err != nil {
+			t.Fatalf("CreateEvent() error = %v", err)
+		}
+		sourceID, err := AddObservation(db, entityID, "supersededonlytoken", "user", 1.0, eventID)
+		if err != nil {
+			t.Fatalf("AddObservation(source) error = %v", err)
+		}
+		targetID, err := AddObservation(db, entityID, "active replacement token", "user", 1.0, eventID)
+		if err != nil {
+			t.Fatalf("AddObservation(target) error = %v", err)
+		}
+		markObservationSupersededForTest(t, db, sourceID, targetID, "test_supersession")
+
+		searchResults, _, err := SearchMemory(db, "supersededonlytoken", 10, 12)
+		if err != nil {
+			t.Fatalf("SearchMemory() error = %v", err)
+		}
+		if len(searchResults) != 0 {
+			t.Fatalf("SearchMemory returned superseded observation: %#v", searchResults)
+		}
+
+		graph, err := GetEntityGraph(db, "SupersededSurfaceEntity", 12)
+		if err != nil {
+			t.Fatalf("GetEntityGraph() error = %v", err)
+		}
+		if graph == nil || len(graph.Observations) != 1 || graph.Observations[0].ID != targetID {
+			t.Fatalf("GetEntityGraph() = %#v, want only target observation %d", graph, targetID)
+		}
+
+		listed, err := ListEntities(db, "", 50)
+		if err != nil {
+			t.Fatalf("ListEntities() error = %v", err)
+		}
+		listedEntity, ok := listedEntityByName(listed, "SupersededSurfaceEntity")
+		if !ok {
+			t.Fatalf("superseded test entity missing from ListEntities")
+		}
+		if listedEntity.ObservationCount != 1 {
+			t.Fatalf("ListEntities observation_count = %d, want 1", listedEntity.ObservationCount)
+		}
+
+		byID, err := GetObservationsByIDs(db, []int64{sourceID, targetID}, 12)
+		if err != nil {
+			t.Fatalf("GetObservationsByIDs() error = %v", err)
+		}
+		if byID.Total != 1 || len(byID.Observations) != 1 || byID.Observations[0].ID != targetID {
+			t.Fatalf("GetObservationsByIDs() = %#v, want only target observation %d", byID, targetID)
+		}
+
+		fullEvent, err := GetFullEvent(db, eventID, 12)
+		if err != nil {
+			t.Fatalf("GetFullEvent() error = %v", err)
+		}
+		if fullEvent == nil || fullEvent.TotalObservations != 1 || len(fullEvent.Entities) != 1 {
+			t.Fatalf("GetFullEvent() = %#v, want one active observation", fullEvent)
+		}
+		group := fullEvent.Entities[0]
+		if len(group.Observations) != 1 || group.Observations[0].ID != targetID {
+			t.Fatalf("GetFullEvent observations = %#v, want only target observation %d", group.Observations, targetID)
+		}
+
+		eventObservations, err := GetEventObservations(db, eventID, 12)
+		if err != nil {
+			t.Fatalf("GetEventObservations() error = %v", err)
+		}
+		if eventObservations == nil || eventObservations.Total != 1 || len(eventObservations.Observations) != 1 || eventObservations.Observations[0].ID != targetID {
+			t.Fatalf("GetEventObservations() = %#v, want only target observation %d", eventObservations, targetID)
+		}
+
+		events, err := SearchEvents(db, "Superseded visibility event", "", "", "", 5)
+		if err != nil {
+			t.Fatalf("SearchEvents() error = %v", err)
+		}
+		if len(events) != 1 || events[0].ObservationCount != 1 {
+			t.Fatalf("SearchEvents() = %#v, want one counted active observation", events)
 		}
 	})
 

--- a/internal/store/parity_test.go
+++ b/internal/store/parity_test.go
@@ -539,6 +539,42 @@ func TestEventsAndProvenanceParity(t *testing.T) {
 		}
 	})
 
+	t.Run("inactive supersession target does not resurrect source", func(t *testing.T) {
+		entityID, err := UpsertEntity(db, "SupersededTargetForgottenEntity", "test")
+		if err != nil {
+			t.Fatalf("UpsertEntity() error = %v", err)
+		}
+		sourceID, err := AddObservation(db, entityID, "targetforgottensourcetoken", "user", 1.0)
+		if err != nil {
+			t.Fatalf("AddObservation(source) error = %v", err)
+		}
+		targetID, err := AddObservation(db, entityID, "targetforgottentargettoken", "user", 1.0)
+		if err != nil {
+			t.Fatalf("AddObservation(target) error = %v", err)
+		}
+		markObservationSupersededForTest(t, db, sourceID, targetID, "test_supersession")
+		if forgotten, err := ForgetObservation(db, targetID); err != nil {
+			t.Fatalf("ForgetObservation(target) error = %v", err)
+		} else if !forgotten {
+			t.Fatalf("ForgetObservation(target) = false, want true")
+		}
+
+		results, _, err := SearchMemory(db, "targetforgotten", 10, 12)
+		if err != nil {
+			t.Fatalf("SearchMemory() error = %v", err)
+		}
+		if len(results) != 0 {
+			t.Fatalf("SearchMemory resurrected superseded source or forgotten target: %#v", results)
+		}
+		byID, err := GetObservationsByIDs(db, []int64{sourceID, targetID}, 12)
+		if err != nil {
+			t.Fatalf("GetObservationsByIDs() error = %v", err)
+		}
+		if byID.Total != 0 || len(byID.Observations) != 0 {
+			t.Fatalf("GetObservationsByIDs() = %#v, want no active observations", byID)
+		}
+	})
+
 	t.Run("tombstoned entity drift disappears from event counts and label candidates", func(t *testing.T) {
 		entityID, err := UpsertEntity(db, "EventLabelTombstoneEntity", "test")
 		if err != nil {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -425,6 +425,8 @@ func InitSchema(db *sql.DB) error {
 
 	postMigrationStmts := []string{
 		`CREATE INDEX IF NOT EXISTS idx_obs_event ON observations(event_id);`,
+		`CREATE INDEX IF NOT EXISTS idx_obs_active_entity_content ON observations(entity_id, content) WHERE deleted_at IS NULL AND superseded_by IS NULL;`,
+		`CREATE INDEX IF NOT EXISTS idx_obs_active_event ON observations(event_id) WHERE deleted_at IS NULL AND superseded_by IS NULL;`,
 		`CREATE INDEX IF NOT EXISTS idx_obs_superseded ON observations(superseded_by) WHERE superseded_by IS NOT NULL;`,
 		`CREATE INDEX IF NOT EXISTS idx_obs_superseded_run ON observations(superseded_by_run) WHERE superseded_by_run IS NOT NULL;`,
 		`CREATE INDEX IF NOT EXISTS idx_reconcile_decisions_run ON reconcile_decisions(run_id);`,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -84,6 +84,65 @@ var schemaMigrations = []schemaMigration{
 		SQL:     `ALTER TABLE entities ADD COLUMN updated_at TEXT`,
 		PostSQL: []string{`UPDATE entities SET updated_at = COALESCE(updated_at, CURRENT_TIMESTAMP)`},
 	},
+	{
+		Version: 9,
+		Table:   "reconcile_runs",
+		Column:  "id",
+		SQL: `CREATE TABLE IF NOT EXISTS reconcile_runs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now')),
+			mode TEXT NOT NULL,
+			trigger_source TEXT,
+			scope TEXT NOT NULL,
+			scanned_entities INTEGER NOT NULL DEFAULT 0,
+			candidates_proposed INTEGER NOT NULL DEFAULT 0,
+			supersessions_applied INTEGER NOT NULL DEFAULT 0,
+			duration_ms INTEGER NOT NULL DEFAULT 0,
+			notes TEXT
+		);`,
+	},
+	{
+		Version: 10,
+		Table:   "observations",
+		Column:  "superseded_by",
+		SQL:     `ALTER TABLE observations ADD COLUMN superseded_by INTEGER REFERENCES observations(id)`,
+	},
+	{
+		Version: 11,
+		Table:   "observations",
+		Column:  "superseded_at",
+		SQL:     `ALTER TABLE observations ADD COLUMN superseded_at TEXT`,
+	},
+	{
+		Version: 12,
+		Table:   "observations",
+		Column:  "superseded_reason",
+		SQL:     `ALTER TABLE observations ADD COLUMN superseded_reason TEXT`,
+	},
+	{
+		Version: 13,
+		Table:   "observations",
+		Column:  "superseded_by_run",
+		SQL:     `ALTER TABLE observations ADD COLUMN superseded_by_run INTEGER REFERENCES reconcile_runs(id)`,
+	},
+	{
+		Version: 14,
+		Table:   "reconcile_decisions",
+		Column:  "id",
+		SQL: `CREATE TABLE IF NOT EXISTS reconcile_decisions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			run_id INTEGER NOT NULL REFERENCES reconcile_runs(id) ON DELETE CASCADE,
+			kind TEXT NOT NULL,
+			entity_id INTEGER,
+			source_obs_ids TEXT NOT NULL,
+			target_obs_id INTEGER,
+			similarity REAL,
+			action TEXT NOT NULL,
+			rationale TEXT,
+			reverted_at TEXT,
+			reverted_by_run INTEGER REFERENCES reconcile_runs(id)
+		);`,
+	},
 }
 
 type CanaryResult struct {
@@ -275,6 +334,18 @@ func InitSchema(db *sql.DB) error {
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);`,
+		`CREATE TABLE IF NOT EXISTS reconcile_runs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now')),
+			mode TEXT NOT NULL,
+			trigger_source TEXT,
+			scope TEXT NOT NULL,
+			scanned_entities INTEGER NOT NULL DEFAULT 0,
+			candidates_proposed INTEGER NOT NULL DEFAULT 0,
+			supersessions_applied INTEGER NOT NULL DEFAULT 0,
+			duration_ms INTEGER NOT NULL DEFAULT 0,
+			notes TEXT
+		);`,
 		`CREATE TABLE IF NOT EXISTS observations (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			entity_id INTEGER NOT NULL,
@@ -286,6 +357,10 @@ func InitSchema(db *sql.DB) error {
 			event_id INTEGER,
 			entity_type TEXT,
 			deleted_at TEXT,
+			superseded_by INTEGER REFERENCES observations(id),
+			superseded_at TEXT,
+			superseded_reason TEXT,
+			superseded_by_run INTEGER REFERENCES reconcile_runs(id),
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			FOREIGN KEY(entity_id) REFERENCES entities(id) ON DELETE CASCADE,
 			FOREIGN KEY(event_id) REFERENCES events(id)
@@ -307,6 +382,19 @@ func InitSchema(db *sql.DB) error {
 			context TEXT,
 			expires_at TEXT,
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);`,
+		`CREATE TABLE IF NOT EXISTS reconcile_decisions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			run_id INTEGER NOT NULL REFERENCES reconcile_runs(id) ON DELETE CASCADE,
+			kind TEXT NOT NULL,
+			entity_id INTEGER,
+			source_obs_ids TEXT NOT NULL,
+			target_obs_id INTEGER,
+			similarity REAL,
+			action TEXT NOT NULL,
+			rationale TEXT,
+			reverted_at TEXT,
+			reverted_by_run INTEGER REFERENCES reconcile_runs(id)
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_obs_entity ON observations(entity_id);`,
 		`CREATE INDEX IF NOT EXISTS idx_obs_content ON observations(content);`,
@@ -337,6 +425,11 @@ func InitSchema(db *sql.DB) error {
 
 	postMigrationStmts := []string{
 		`CREATE INDEX IF NOT EXISTS idx_obs_event ON observations(event_id);`,
+		`CREATE INDEX IF NOT EXISTS idx_obs_superseded ON observations(superseded_by) WHERE superseded_by IS NOT NULL;`,
+		`CREATE INDEX IF NOT EXISTS idx_obs_superseded_run ON observations(superseded_by_run) WHERE superseded_by_run IS NOT NULL;`,
+		`CREATE INDEX IF NOT EXISTS idx_reconcile_decisions_run ON reconcile_decisions(run_id);`,
+		`CREATE INDEX IF NOT EXISTS idx_reconcile_decisions_kind ON reconcile_decisions(kind);`,
+		`CREATE INDEX IF NOT EXISTS idx_reconcile_decisions_entity ON reconcile_decisions(entity_id);`,
 		`CREATE INDEX IF NOT EXISTS idx_entities_deleted ON entities(deleted_at);`,
 		`CREATE INDEX IF NOT EXISTS idx_obs_deleted ON observations(deleted_at);`,
 		`CREATE TRIGGER IF NOT EXISTS trg_entities_insert_timestamps
@@ -575,7 +668,7 @@ func TouchObservations(db *sql.DB, observationIDs []int64) error {
 			args = append(args, id)
 		}
 		if _, err := db.Exec(
-			fmt.Sprintf(`UPDATE observations SET access_count = access_count + 1, last_accessed = CURRENT_TIMESTAMP WHERE id IN (%s) AND deleted_at IS NULL`, placeholders),
+			fmt.Sprintf(`UPDATE observations SET access_count = access_count + 1, last_accessed = CURRENT_TIMESTAMP WHERE id IN (%s) AND deleted_at IS NULL AND superseded_by IS NULL`, placeholders),
 			args...,
 		); err != nil {
 			return fmt.Errorf("touch observations: %w", err)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -133,9 +133,9 @@ var schemaMigrations = []schemaMigration{
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			run_id INTEGER NOT NULL REFERENCES reconcile_runs(id) ON DELETE CASCADE,
 			kind TEXT NOT NULL,
-			entity_id INTEGER,
+			entity_id INTEGER REFERENCES entities(id),
 			source_obs_ids TEXT NOT NULL,
-			target_obs_id INTEGER,
+			target_obs_id INTEGER REFERENCES observations(id),
 			similarity REAL,
 			action TEXT NOT NULL,
 			rationale TEXT,
@@ -387,9 +387,9 @@ func InitSchema(db *sql.DB) error {
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			run_id INTEGER NOT NULL REFERENCES reconcile_runs(id) ON DELETE CASCADE,
 			kind TEXT NOT NULL,
-			entity_id INTEGER,
+			entity_id INTEGER REFERENCES entities(id),
 			source_obs_ids TEXT NOT NULL,
-			target_obs_id INTEGER,
+			target_obs_id INTEGER REFERENCES observations(id),
 			similarity REAL,
 			action TEXT NOT NULL,
 			rationale TEXT,
@@ -668,7 +668,9 @@ func TouchObservations(db *sql.DB, observationIDs []int64) error {
 			args = append(args, id)
 		}
 		if _, err := db.Exec(
-			fmt.Sprintf(`UPDATE observations SET access_count = access_count + 1, last_accessed = CURRENT_TIMESTAMP WHERE id IN (%s) AND deleted_at IS NULL AND superseded_by IS NULL`, placeholders),
+			fmt.Sprintf(`UPDATE observations SET access_count = access_count + 1, last_accessed = CURRENT_TIMESTAMP
+				WHERE id IN (%s) AND %s
+				  AND EXISTS (SELECT 1 FROM entities e WHERE e.id = observations.entity_id AND e.deleted_at IS NULL)`, placeholders, activeObservationSQL("observations")),
 			args...,
 		); err != nil {
 			return fmt.Errorf("touch observations: %w", err)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -338,7 +338,48 @@ func TestInitDBRecordsSchemaMigrationsAndIsIdempotent(t *testing.T) {
 	}
 }
 
-func TestReconcileDecisionsEnforceEntityAndTargetForeignKeys(t *testing.T) {
+func TestSupersessionColumnsEnforceForeignKeys(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "supersession-column-fks.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	runResult, err := db.Exec(`INSERT INTO reconcile_runs (mode, trigger_source, scope) VALUES (?, ?, ?)`, "apply", "manual", "global")
+	if err != nil {
+		t.Fatalf("insert reconcile run error = %v", err)
+	}
+	runID, err := runResult.LastInsertId()
+	if err != nil {
+		t.Fatalf("run LastInsertId error = %v", err)
+	}
+	entityID, err := UpsertEntity(db, "SupersessionFKEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	sourceID, err := AddObservation(db, entityID, "supersession fk source", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(source) error = %v", err)
+	}
+	targetID, err := AddObservation(db, entityID, "supersession fk target", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(target) error = %v", err)
+	}
+
+	if _, err := db.Exec(`UPDATE observations SET superseded_by = ?, superseded_by_run = ? WHERE id = ?`, targetID, runID, sourceID); err != nil {
+		t.Fatalf("valid supersession FK update error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE observations SET superseded_by = ? WHERE id = ?`, int64(999999), sourceID); !isForeignKeyConstraint(err) {
+		t.Fatalf("invalid superseded_by error = %v, want foreign key constraint", err)
+	}
+	if _, err := db.Exec(`UPDATE observations SET superseded_by_run = ? WHERE id = ?`, int64(999999), sourceID); !isForeignKeyConstraint(err) {
+		t.Fatalf("invalid superseded_by_run error = %v, want foreign key constraint", err)
+	}
+}
+
+func TestReconcileDecisionsEnforceForeignKeys(t *testing.T) {
 	t.Parallel()
 
 	db, err := InitDB(filepath.Join(t.TempDir(), "reconcile-decision-fks.db"))
@@ -372,6 +413,12 @@ func TestReconcileDecisionsEnforceEntityAndTargetForeignKeys(t *testing.T) {
 	}
 	if _, err := db.Exec(`INSERT INTO reconcile_decisions (run_id, kind, entity_id, source_obs_ids, target_obs_id, action) VALUES (?, ?, ?, ?, ?, ?)`, runID, "exact_duplicate", entityID, "[]", int64(999999), "proposed"); !isForeignKeyConstraint(err) {
 		t.Fatalf("invalid target_obs_id error = %v, want foreign key constraint", err)
+	}
+	if _, err := db.Exec(`INSERT INTO reconcile_decisions (run_id, kind, entity_id, source_obs_ids, target_obs_id, action) VALUES (?, ?, ?, ?, ?, ?)`, int64(999999), "exact_duplicate", entityID, "[]", observationID, "proposed"); !isForeignKeyConstraint(err) {
+		t.Fatalf("invalid run_id error = %v, want foreign key constraint", err)
+	}
+	if _, err := db.Exec(`UPDATE reconcile_decisions SET reverted_by_run = ? WHERE run_id = ?`, int64(999999), runID); !isForeignKeyConstraint(err) {
+		t.Fatalf("invalid reverted_by_run error = %v, want foreign key constraint", err)
 	}
 }
 
@@ -873,12 +920,14 @@ func TestInitDBMigratesPreRegistryLegacySchema(t *testing.T) {
 		}
 	}
 
-	var eventIndexCount int
-	if err := migratedDB.QueryRow(`SELECT COUNT(*) FROM pragma_index_list('observations') WHERE name = 'idx_obs_event'`).Scan(&eventIndexCount); err != nil {
-		t.Fatalf("pragma_index_list(observations) error = %v", err)
-	}
-	if eventIndexCount != 1 {
-		t.Fatalf("idx_obs_event count = %d, want 1", eventIndexCount)
+	for _, indexName := range []string{"idx_obs_event", "idx_obs_active_entity_content", "idx_obs_active_event"} {
+		var indexCount int
+		if err := migratedDB.QueryRow(`SELECT COUNT(*) FROM pragma_index_list('observations') WHERE name = ?`, indexName).Scan(&indexCount); err != nil {
+			t.Fatalf("pragma_index_list(observations) error = %v", err)
+		}
+		if indexCount != 1 {
+			t.Fatalf("%s count = %d, want 1", indexName, indexCount)
+		}
 	}
 
 	entityID, err := UpsertEntity(migratedDB, "LegacyTimestampProbe", "test")

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -316,6 +316,26 @@ func TestInitDBRecordsSchemaMigrationsAndIsIdempotent(t *testing.T) {
 	if missingAppliedAt != 0 {
 		t.Fatalf("schema_migrations rows with empty applied_at = %d, want 0", missingAppliedAt)
 	}
+	for _, check := range []struct {
+		table  string
+		column string
+	}{
+		{table: "observations", column: "superseded_by"},
+		{table: "observations", column: "superseded_at"},
+		{table: "observations", column: "superseded_reason"},
+		{table: "observations", column: "superseded_by_run"},
+		{table: "reconcile_runs", column: "id"},
+		{table: "reconcile_runs", column: "trigger_source"},
+		{table: "reconcile_decisions", column: "id"},
+	} {
+		present, err := columnExists(db, check.table, check.column)
+		if err != nil {
+			t.Fatalf("columnExists(%s.%s) error = %v", check.table, check.column, err)
+		}
+		if !present {
+			t.Fatalf("%s.%s missing after InitDB", check.table, check.column)
+		}
+	}
 }
 
 func TestSearchObservationIDsHonorsExpiryGuard(t *testing.T) {
@@ -348,6 +368,80 @@ func TestSearchObservationIDsHonorsExpiryGuard(t *testing.T) {
 	}
 	if len(ids) != 0 {
 		t.Fatalf("SearchObservationIDs returned expired observation ids: %#v", ids)
+	}
+}
+
+func TestSearchObservationIDsHonorsSupersessionGuard(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "search-ids-supersession.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	entityID, err := UpsertEntity(db, "SearchIDsSupersession", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	sourceID, err := AddObservation(db, entityID, "supersededsearchidtoken", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(source) error = %v", err)
+	}
+	targetID, err := AddObservation(db, entityID, "active replacement search id token", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(target) error = %v", err)
+	}
+	markObservationSupersededForTest(t, db, sourceID, targetID, "test_supersession")
+
+	ids, err := SearchObservationIDs(db, "supersededsearchidtoken")
+	if err != nil {
+		t.Fatalf("SearchObservationIDs() error = %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("SearchObservationIDs returned superseded observation ids: %#v", ids)
+	}
+}
+
+func TestTouchObservationsSkipsSupersededRows(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "touch-superseded.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	entityID, err := UpsertEntity(db, "TouchSuperseded", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	sourceID, err := AddObservation(db, entityID, "superseded touch source", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(source) error = %v", err)
+	}
+	targetID, err := AddObservation(db, entityID, "active touch target", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(target) error = %v", err)
+	}
+	markObservationSupersededForTest(t, db, sourceID, targetID, "test_supersession")
+
+	if err := TouchObservations(db, []int64{sourceID, targetID}); err != nil {
+		t.Fatalf("TouchObservations() error = %v", err)
+	}
+
+	var sourceAccessCount, targetAccessCount int
+	if err := db.QueryRow(`SELECT access_count FROM observations WHERE id = ?`, sourceID).Scan(&sourceAccessCount); err != nil {
+		t.Fatalf("read source access_count error = %v", err)
+	}
+	if err := db.QueryRow(`SELECT access_count FROM observations WHERE id = ?`, targetID).Scan(&targetAccessCount); err != nil {
+		t.Fatalf("read target access_count error = %v", err)
+	}
+	if sourceAccessCount != 0 {
+		t.Fatalf("superseded source access_count = %d, want 0", sourceAccessCount)
+	}
+	if targetAccessCount != 1 {
+		t.Fatalf("active target access_count = %d, want 1", targetAccessCount)
 	}
 }
 
@@ -519,6 +613,15 @@ func TestInitDBMigratesLegacyProjectSchemaBeforeDeletedIndexes(t *testing.T) {
 	if deletedIndexCount != 1 {
 		t.Fatalf("idx_entities_deleted count = %d, want 1", deletedIndexCount)
 	}
+	for _, table := range []string{"reconcile_runs", "reconcile_decisions"} {
+		exists, err := tableExists(migratedDB, table)
+		if err != nil {
+			t.Fatalf("tableExists(%s) error = %v", table, err)
+		}
+		if !exists {
+			t.Fatalf("%s table missing after migration", table)
+		}
+	}
 	assertSchemaMigrationCount(t, migratedDB, len(schemaMigrations))
 	if err := InitSchema(migratedDB); err != nil {
 		t.Fatalf("InitSchema() second pass on legacy migration error = %v", err)
@@ -594,8 +697,15 @@ func TestInitDBMigratesPreRegistryLegacySchema(t *testing.T) {
 		{table: "observations", column: "event_id"},
 		{table: "observations", column: "deleted_at"},
 		{table: "observations", column: "entity_type"},
+		{table: "observations", column: "superseded_by"},
+		{table: "observations", column: "superseded_at"},
+		{table: "observations", column: "superseded_reason"},
+		{table: "observations", column: "superseded_by_run"},
 		{table: "entities", column: "created_at"},
 		{table: "entities", column: "updated_at"},
+		{table: "reconcile_runs", column: "id"},
+		{table: "reconcile_runs", column: "trigger_source"},
+		{table: "reconcile_decisions", column: "id"},
 	} {
 		present, err := columnExists(migratedDB, check.table, check.column)
 		if err != nil {
@@ -635,6 +745,14 @@ func TestInitDBMigratesPreRegistryLegacySchema(t *testing.T) {
 	if createdAt == "" || updatedAt == "" {
 		t.Fatalf("direct insert created_at=%q updated_at=%q, want trigger-populated timestamps", createdAt, updatedAt)
 	}
+}
+
+func tableExists(tdb *sql.DB, table string) (bool, error) {
+	var count int
+	if err := tdb.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, table).Scan(&count); err != nil {
+		return false, err
+	}
+	return count == 1, nil
 }
 
 func assertSchemaMigrationCount(t *testing.T, db *sql.DB, want int) {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -338,6 +338,43 @@ func TestInitDBRecordsSchemaMigrationsAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestReconcileDecisionsEnforceEntityAndTargetForeignKeys(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "reconcile-decision-fks.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	defer db.Close()
+
+	runResult, err := db.Exec(`INSERT INTO reconcile_runs (mode, trigger_source, scope) VALUES (?, ?, ?)`, "propose", "manual", "global")
+	if err != nil {
+		t.Fatalf("insert reconcile run error = %v", err)
+	}
+	runID, err := runResult.LastInsertId()
+	if err != nil {
+		t.Fatalf("run LastInsertId error = %v", err)
+	}
+	entityID, err := UpsertEntity(db, "ReconcileFKEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	observationID, err := AddObservation(db, entityID, "reconcile fk target", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation() error = %v", err)
+	}
+
+	if _, err := db.Exec(`INSERT INTO reconcile_decisions (run_id, kind, entity_id, source_obs_ids, target_obs_id, action) VALUES (?, ?, ?, ?, ?, ?)`, runID, "exact_duplicate", entityID, "[]", observationID, "proposed"); err != nil {
+		t.Fatalf("insert valid reconcile decision error = %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO reconcile_decisions (run_id, kind, entity_id, source_obs_ids, target_obs_id, action) VALUES (?, ?, ?, ?, ?, ?)`, runID, "exact_duplicate", int64(999999), "[]", observationID, "proposed"); !isForeignKeyConstraint(err) {
+		t.Fatalf("invalid entity_id error = %v, want foreign key constraint", err)
+	}
+	if _, err := db.Exec(`INSERT INTO reconcile_decisions (run_id, kind, entity_id, source_obs_ids, target_obs_id, action) VALUES (?, ?, ?, ?, ?, ?)`, runID, "exact_duplicate", entityID, "[]", int64(999999), "proposed"); !isForeignKeyConstraint(err) {
+		t.Fatalf("invalid target_obs_id error = %v, want foreign key constraint", err)
+	}
+}
+
 func TestSearchObservationIDsHonorsExpiryGuard(t *testing.T) {
 	t.Parallel()
 
@@ -403,10 +440,10 @@ func TestSearchObservationIDsHonorsSupersessionGuard(t *testing.T) {
 	}
 }
 
-func TestTouchObservationsSkipsSupersededRows(t *testing.T) {
+func TestTouchObservationsSkipsInactiveRows(t *testing.T) {
 	t.Parallel()
 
-	db, err := InitDB(filepath.Join(t.TempDir(), "touch-superseded.db"))
+	db, err := InitDB(filepath.Join(t.TempDir(), "touch-inactive.db"))
 	if err != nil {
 		t.Fatalf("InitDB() error = %v", err)
 	}
@@ -426,23 +463,143 @@ func TestTouchObservationsSkipsSupersededRows(t *testing.T) {
 	}
 	markObservationSupersededForTest(t, db, sourceID, targetID, "test_supersession")
 
-	if err := TouchObservations(db, []int64{sourceID, targetID}); err != nil {
+	tombstonedEntityID, err := UpsertEntity(db, "TouchTombstonedEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity(tombstoned) error = %v", err)
+	}
+	tombstonedEntityObservationID, err := AddObservation(db, tombstonedEntityID, "tombstoned entity touch source", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(tombstoned entity) error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE entities SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`, tombstonedEntityID); err != nil {
+		t.Fatalf("tombstone entity error = %v", err)
+	}
+
+	expiredEventID, err := CreateEvent(db, "Touch expired event", "", "test", "", "")
+	if err != nil {
+		t.Fatalf("CreateEvent(expired) error = %v", err)
+	}
+	expiredEventEntityID, err := UpsertEntity(db, "TouchExpiredEventEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity(expired event) error = %v", err)
+	}
+	expiredEventObservationID, err := AddObservation(db, expiredEventEntityID, "expired event touch source", "user", 1.0, expiredEventID)
+	if err != nil {
+		t.Fatalf("AddObservation(expired event) error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE events SET expires_at = ? WHERE id = ?`, time.Now().Add(-1*time.Hour).UTC().Format(sqliteTimestampLayout), expiredEventID); err != nil {
+		t.Fatalf("expire event error = %v", err)
+	}
+
+	deletedEntityID, err := UpsertEntity(db, "TouchDeletedObservationEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity(deleted observation) error = %v", err)
+	}
+	deletedObservationID, err := AddObservation(db, deletedEntityID, "deleted observation touch source", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(deleted observation) error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE observations SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`, deletedObservationID); err != nil {
+		t.Fatalf("tombstone observation error = %v", err)
+	}
+
+	ids := []int64{sourceID, targetID, tombstonedEntityObservationID, expiredEventObservationID, deletedObservationID}
+	if err := TouchObservations(db, ids); err != nil {
 		t.Fatalf("TouchObservations() error = %v", err)
 	}
 
-	var sourceAccessCount, targetAccessCount int
-	if err := db.QueryRow(`SELECT access_count FROM observations WHERE id = ?`, sourceID).Scan(&sourceAccessCount); err != nil {
-		t.Fatalf("read source access_count error = %v", err)
+	for _, check := range []struct {
+		name string
+		id   int64
+		want int
+	}{
+		{name: "superseded source", id: sourceID, want: 0},
+		{name: "active target", id: targetID, want: 1},
+		{name: "tombstoned entity", id: tombstonedEntityObservationID, want: 0},
+		{name: "expired event", id: expiredEventObservationID, want: 0},
+		{name: "deleted observation", id: deletedObservationID, want: 0},
+	} {
+		var got int
+		if err := db.QueryRow(`SELECT access_count FROM observations WHERE id = ?`, check.id).Scan(&got); err != nil {
+			t.Fatalf("read %s access_count error = %v", check.name, err)
+		}
+		if got != check.want {
+			t.Fatalf("%s access_count = %d, want %d", check.name, got, check.want)
+		}
 	}
-	if err := db.QueryRow(`SELECT access_count FROM observations WHERE id = ?`, targetID).Scan(&targetAccessCount); err != nil {
-		t.Fatalf("read target access_count error = %v", err)
+}
+
+func TestForgetCleansFTSForSupersededObservations(t *testing.T) {
+	t.Parallel()
+
+	db, err := InitDB(filepath.Join(t.TempDir(), "forget-superseded-fts.db"))
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
 	}
-	if sourceAccessCount != 0 {
-		t.Fatalf("superseded source access_count = %d, want 0", sourceAccessCount)
+	defer db.Close()
+
+	entityID, err := UpsertEntity(db, "SupersededForgetObservation", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity(observation) error = %v", err)
 	}
-	if targetAccessCount != 1 {
-		t.Fatalf("active target access_count = %d, want 1", targetAccessCount)
+	observationSourceID, err := AddObservation(db, entityID, "supersededforgetobservationtoken", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(observation source) error = %v", err)
 	}
+	observationTargetID, err := AddObservation(db, entityID, "canonical replacement observation", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(observation target) error = %v", err)
+	}
+	markObservationSupersededForTest(t, db, observationSourceID, observationTargetID, "test_supersession")
+	if got := rawFTSMatchCountForTest(t, db, "supersededforgetobservationtoken"); got != 1 {
+		t.Fatalf("raw FTS count before ForgetObservation = %d, want 1", got)
+	}
+	deleted, err := ForgetObservation(db, observationSourceID)
+	if err != nil {
+		t.Fatalf("ForgetObservation() error = %v", err)
+	}
+	if !deleted {
+		t.Fatalf("ForgetObservation() deleted = false, want true")
+	}
+	if got := rawFTSMatchCountForTest(t, db, "supersededforgetobservationtoken"); got != 0 {
+		t.Fatalf("raw FTS count after ForgetObservation = %d, want 0", got)
+	}
+
+	entitySourceID, err := UpsertEntity(db, "SupersededForgetEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity(entity) error = %v", err)
+	}
+	entityObservationSourceID, err := AddObservation(db, entitySourceID, "supersededforgetentitytoken", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(entity source) error = %v", err)
+	}
+	entityObservationTargetID, err := AddObservation(db, entitySourceID, "canonical replacement entity", "user", 1.0)
+	if err != nil {
+		t.Fatalf("AddObservation(entity target) error = %v", err)
+	}
+	markObservationSupersededForTest(t, db, entityObservationSourceID, entityObservationTargetID, "test_supersession")
+	if got := rawFTSMatchCountForTest(t, db, "supersededforgetentitytoken"); got != 1 {
+		t.Fatalf("raw FTS count before ForgetEntity = %d, want 1", got)
+	}
+	forgotten, err := ForgetEntity(db, "SupersededForgetEntity")
+	if err != nil {
+		t.Fatalf("ForgetEntity() error = %v", err)
+	}
+	if !forgotten {
+		t.Fatalf("ForgetEntity() forgotten = false, want true")
+	}
+	if got := rawFTSMatchCountForTest(t, db, "supersededforgetentitytoken"); got != 0 {
+		t.Fatalf("raw FTS count after ForgetEntity = %d, want 0", got)
+	}
+}
+
+func rawFTSMatchCountForTest(t *testing.T, db *sql.DB, query string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM memory_fts WHERE memory_fts MATCH ?`, quoteFTSTerms(query)).Scan(&count); err != nil {
+		t.Fatalf("raw FTS count error = %v", err)
+	}
+	return count
 }
 
 func TestForgetObservationUsesIndexedEntityTypeSnapshot(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add migration-tracked supersession columns plus `reconcile_runs` / `reconcile_decisions` audit tables for reconcile v0.
- Hide superseded observations from active-memory read paths, including recall, entity/event/provenance hydration, counts, FTS ID search, touches, and conflict hints.
- Update canonical docs/reviewer guidance and add regression coverage for fresh schema, legacy migrations, supersession visibility, and touch behavior.

## Validation
- `go test ./...`
- `git diff --check`
- Tripartite local review completed: no blockers; cheap risks addressed before commit.

## Scope notes
- No reconcile CLI, embeddings, remote provider, or summarization behavior in this PR.
- Supersession FTS rows remain physically present and hidden via active-observation joins; tombstone/forget remains the physical FTS cleanup path.