### PR TITLE
feat: add read-only reconcile propose reports

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -127,8 +127,8 @@ Contract properties:
   list moves.
 - Superseded observations are not active observations and are not candidates for
   `possible_conflicts`. A later identical write can create a new active
-  observation; deterministic reconcile is responsible for cleaning that up once
-  the runner exists.
+  observation; deterministic reconcile propose reports those duplicates, and a
+  later apply step will be responsible for cleaning them up.
 - The similarity threshold is provisional at launch and calibrated via
   telemetry (`conflicts_surfaced` vs `conflicts_acted_on`). Threshold
   changes are implementation-internal and do not constitute a contract

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,6 +98,7 @@ cmd/workmem/
 internal/backup/
 internal/dotenv/
 internal/mcpserver/
+internal/reconcile/
 internal/store/
 internal/telemetry/
 docs/

--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -1,5 +1,46 @@
 # DECISION LOG
 
+## 2026-05-02: Reconcile propose mode reports exact duplicates without mutation
+
+### Context
+
+Step 6.1 added supersession lifecycle plumbing, but the first runnable reconcile
+surface still needed to prove that memory hygiene can be inspected without
+changing active memory. The product constraint remains local-first and
+audit-first: no embeddings, no remote providers, and no apply path until report
+quality is observable.
+
+### Decision
+
+Ship `workmem reconcile --mode propose` as a read-only exact-duplicate reporter.
+It scans active observations within global or project scope, finds exact content
+duplicates within the same entity, chooses the newest duplicate as the proposed
+target, and writes a markdown report under ignored `review/` by default. Propose
+mode opens the memory database read-only and does not create missing DBs, mutate
+observations, touch access counts, or write reconcile audit tables.
+
+### Rationale
+
+- Exact duplicates are deterministic enough to report before any semantic model
+  exists.
+- Keeping propose free of audit writes makes the Step 6.2 gate honest: the first
+  CLI run is an inspection surface, not a partial apply system.
+- Opening the DB read-only prevents schema migrations, WAL mode changes, or
+  project `.memory` creation from hiding inside an audit command.
+- Project scope support exercises the real per-project DB path before apply and
+  rollback introduce mutations.
+- Markdown reports give humans and reviewers evidence before the runner gets
+  authority to change memory.
+
+### Alternatives considered
+
+- **Insert `reconcile_runs` rows in propose mode.** Deferred to apply/rollback.
+  The Step 6.2 gate explicitly requires no memory DB mutations.
+- **Start with semantic similarity.** Rejected for v0; exact duplicates are the
+  safe proof case.
+- **Only support global scope initially.** Rejected because project/global drift
+  is a recurring risk class and cheap to prevent here.
+
 ## 2026-05-02: Reconcile v0 starts with deterministic supersession plumbing
 
 ### Context

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -286,15 +286,20 @@ legacy DBs, and no reconcile CLI exists yet.
 **On Step Gate (all items [x]):** focused correctness review before building
 the reconcile CLI.
 
-### Step 6.2: Deterministic propose report [⏸]
+### Step 6.2: Deterministic propose report [✅]
 
 Implement `workmem reconcile` in propose mode only. **Gate:** exact duplicate
 candidates are reported in markdown with no memory mutations.
 
-- [ ] Add `workmem reconcile --mode propose`
-- [ ] Detect exact duplicate observations within the same entity
-- [ ] Write markdown report under ignored `review/`
-- [ ] Support global and project scopes
+- [x] Add `workmem reconcile --mode propose`
+- [x] Detect exact duplicate observations within the same entity
+- [x] Write markdown report under ignored `review/`
+- [x] Support global and project scopes
+- [x] Prove propose mode does not mutate observations, access counts, or audit
+  rows
+
+**On Step Gate (all items [x]):** focused correctness review before adding
+apply/rollback mutation paths.
 
 ### Step 6.3: Exact duplicate apply and rollback [⏸]
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -72,14 +72,14 @@ Done when: either the threshold has been confirmed twice in a row at the same va
 - Until `workmem reconcile --mode apply` exists, superseded observations are
   hidden but cannot be produced by a first-class write path. Exact content
   matching a superseded observation can be remembered again as a new active
-  observation; Step 6.3 will clean deterministic duplicates through audited
-  supersession.
+  observation; `workmem reconcile --mode propose` reports deterministic
+  duplicates and Step 6.3 will clean them through audited supersession.
 Trigger: a user or future migration manually marks observations superseded, then
 the same content is remembered again before the runner exists.
 Blast radius: harmless duplicate active observations that the future deterministic
 reconcile step must collapse.
-Fix: implement Step 6.2/6.3 exact duplicate propose/apply and consider conflict
-hints against superseded history only if real reports show this matters.
+Fix: implement Step 6.3 exact duplicate apply/rollback and consider conflict
+hints against superseded history only if propose reports show this matters.
 Done when: exact duplicate reconcile apply/rollback is shipped and tested.
 
 ## Release proof ledger
@@ -91,6 +91,9 @@ Done when: exact duplicate reconcile apply/rollback is shipped and tested.
 - [x] Supersession lifecycle guard: superseded observations hidden from recall,
   entity/event recall, provenance hydration, active counts, FTS ID search, and
   conflict hints.
+- [x] Reconcile propose mode: exact duplicate candidates reported through a
+  read-only DB handle without creating missing DBs or applying observation,
+  access-count, or audit-row mutations.
 - [x] Release artifacts for macOS, Linux, and Windows: covered by CI cross-builds and release workflow artifacts.
 - [x] Install flow on a fresh machine: documented in README and tracked in `IMPLEMENTATION.md` Step 3.3.
 

--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ You have access to a persistent memory store. Use it proactively:
 
 If `remember` returns `possible_conflicts`, review those observations before
 storing more related facts. Use `forget(obs_id)` only when the old fact should
-be deleted/erased. Reversible supersession is planned for the reconcile flow;
-until that command exists, do not edit the database manually to simulate it.
+be deleted/erased. `workmem reconcile --mode propose` can report exact duplicate
+candidates; reversible apply/rollback is planned for a later reconcile step.
 
 Remember: preferences, corrections, names, decisions, conventions.
 Don't remember: transient tasks, code snippets, things already in docs/git.
@@ -279,6 +279,26 @@ age -d -i my-identity.txt backup.age > memory.db
 ```
 
 Only the global memory DB is included. Project-scoped DBs live in their own workspaces and are out of scope. Telemetry data (if enabled) is operational and not included — rebuild freely.
+
+## Reconcile reports
+
+`workmem reconcile --mode propose` runs a read-only hygiene scan and writes a
+local markdown report under `review/` by default:
+
+```bash
+workmem reconcile --mode propose
+workmem reconcile --mode propose --scope project=/path/to/repo
+workmem reconcile --mode propose --since 90d
+workmem reconcile --mode propose --output /tmp/reconcile.md
+```
+
+The v0 runner detects exact duplicate observations within the same entity. It
+opens the memory database read-only and does not create missing global/project
+DBs, apply supersession, mutate observations, or write audit rows; future
+apply/rollback commands will use the reconcile audit tables.
+The `--since` window selects entities with recent observations; once an entity
+is selected, older active source rows can still be reported when they duplicate a
+newer active observation.
 
 ## Design principles
 

--- a/cmd/workmem/main.go
+++ b/cmd/workmem/main.go
@@ -46,6 +46,8 @@ func main() {
 		runSQLiteCanary(os.Args[2:])
 	case os.Args[1] == "backup":
 		runBackup(os.Args[2:])
+	case os.Args[1] == "reconcile":
+		runReconcile(os.Args[2:])
 	case os.Args[1][0] == '-':
 		// no subcommand, treat remaining args as flags for the default (serve) command
 		runMCP(os.Args[1:])
@@ -195,13 +197,21 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  serve           run the MCP server over stdio (default)\n")
 	fmt.Fprintf(os.Stderr, "  sqlite-canary   prove schema init, FTS insert/match/delete, and persistence\n")
 	fmt.Fprintf(os.Stderr, "  backup          write an age-encrypted snapshot of memory.db\n")
+	fmt.Fprintf(os.Stderr, "  reconcile       propose deterministic memory hygiene candidates\n")
 	fmt.Fprintf(os.Stderr, "  version         print build metadata (also: --version / -v)\n\n")
-	fmt.Fprintf(os.Stderr, "flags (serve, sqlite-canary, backup):\n")
+	fmt.Fprintf(os.Stderr, "flags (serve, sqlite-canary, backup, reconcile):\n")
 	fmt.Fprintf(os.Stderr, "  -db <path>        path to the SQLite database file\n")
 	fmt.Fprintf(os.Stderr, "  -env-file <path>  load variables from a .env file (process env takes precedence)\n\n")
 	fmt.Fprintf(os.Stderr, "backup flags:\n")
 	fmt.Fprintf(os.Stderr, "  -to <path>            destination file for the encrypted snapshot (required)\n")
 	fmt.Fprintf(os.Stderr, "  -age-recipient <key>  age recipient (age1... or file path), repeatable, at least one required\n\n")
+	fmt.Fprintf(os.Stderr, "reconcile flags:\n")
+	fmt.Fprintf(os.Stderr, "  -mode propose              v0 supports propose only\n")
+	fmt.Fprintf(os.Stderr, "  -scope global|project=PATH scan global or project memory\n")
+	fmt.Fprintf(os.Stderr, "  -since <duration>          scan entities with recent observations (default: 30d)\n")
+	fmt.Fprintf(os.Stderr, "  -min-obs-per-entity <n>    minimum active observations per scanned entity (default: 2)\n")
+	fmt.Fprintf(os.Stderr, "  -max-entities-per-run <n>  maximum entities to scan (default: 50)\n")
+	fmt.Fprintf(os.Stderr, "  -output <path>             markdown report path (default: review/reconcile-<timestamp>.md)\n\n")
 	fmt.Fprintf(os.Stderr, "restore a backup with the age CLI:\n")
 	fmt.Fprintf(os.Stderr, "  age -d -i <identity-file> <backup.age> > memory.db\n")
 }

--- a/cmd/workmem/main_test.go
+++ b/cmd/workmem/main_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestReconcileProposeCLIWritesReportWithoutAuditRows(t *testing.T) {
-	t.Parallel()
-
 	tmp := t.TempDir()
 	dbPath := filepath.Join(tmp, "memory.db")
 	db, err := store.InitDB(dbPath)
@@ -73,8 +71,6 @@ func TestReconcileProposeCLIWritesReportWithoutAuditRows(t *testing.T) {
 }
 
 func TestReconcileProposeCLISupportsProjectScope(t *testing.T) {
-	t.Parallel()
-
 	projectDir := filepath.Join(t.TempDir(), "project")
 	if err := os.MkdirAll(projectDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll(project) error = %v", err)

--- a/cmd/workmem/main_test.go
+++ b/cmd/workmem/main_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"workmem/internal/store"
+)
+
+func TestReconcileProposeCLIWritesReportWithoutAuditRows(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "memory.db")
+	db, err := store.InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	entityID, err := store.UpsertEntity(db, "CLIReconcileEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	insertCLIRawObservation(t, db, entityID, "cli duplicate content", time.Now().Add(-2*time.Hour))
+	insertCLIRawObservation(t, db, entityID, "cli duplicate content", time.Now().Add(-1*time.Hour))
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close(seed db) error = %v", err)
+	}
+
+	reportPath := filepath.Join(tmp, "reconcile-report.md")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "run", ".", "reconcile", "--db", dbPath, "--output", reportPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run reconcile error = %v\noutput:\n%s", err, string(output))
+	}
+	if !strings.Contains(string(output), "0 mutation(s)") {
+		t.Fatalf("stdout missing mutation summary:\n%s", string(output))
+	}
+	content, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("ReadFile(report) error = %v", err)
+	}
+	if !strings.Contains(string(content), "cli duplicate content") {
+		t.Fatalf("report missing duplicate content:\n%s", string(content))
+	}
+
+	checkDB, err := store.InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("InitDB(check) error = %v", err)
+	}
+	defer checkDB.Close()
+	var reconcileRuns int
+	if err := checkDB.QueryRow(`SELECT COUNT(*) FROM reconcile_runs`).Scan(&reconcileRuns); err != nil {
+		t.Fatalf("count reconcile_runs error = %v", err)
+	}
+	if reconcileRuns != 0 {
+		t.Fatalf("reconcile_runs = %d, want 0 for propose", reconcileRuns)
+	}
+	var reconcileDecisions int
+	if err := checkDB.QueryRow(`SELECT COUNT(*) FROM reconcile_decisions`).Scan(&reconcileDecisions); err != nil {
+		t.Fatalf("count reconcile_decisions error = %v", err)
+	}
+	if reconcileDecisions != 0 {
+		t.Fatalf("reconcile_decisions = %d, want 0 for propose", reconcileDecisions)
+	}
+}
+
+func TestReconcileProposeCLISupportsProjectScope(t *testing.T) {
+	t.Parallel()
+
+	projectDir := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(project) error = %v", err)
+	}
+	projectDB, release, err := store.AcquireDB(nil, projectDir)
+	if err != nil {
+		t.Fatalf("AcquireDB(project) error = %v", err)
+	}
+	entityID, err := store.UpsertEntity(projectDB, "ProjectReconcileEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity(project) error = %v", err)
+	}
+	insertCLIRawObservation(t, projectDB, entityID, "project duplicate content", time.Now().Add(-2*time.Hour))
+	insertCLIRawObservation(t, projectDB, entityID, "project duplicate content", time.Now().Add(-1*time.Hour))
+	release()
+	if err := store.ResetProjectDBs(); err != nil {
+		t.Fatalf("ResetProjectDBs() error = %v", err)
+	}
+
+	reportPath := filepath.Join(t.TempDir(), "project-reconcile.md")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "go", "run", ".", "reconcile", "--scope", "project="+projectDir, "--output", reportPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go run reconcile project error = %v\noutput:\n%s", err, string(output))
+	}
+	content, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("ReadFile(project report) error = %v", err)
+	}
+	if !strings.Contains(string(content), "Scope: project:"+projectDir) {
+		t.Fatalf("project report missing scope:\n%s", string(content))
+	}
+	if !strings.Contains(string(content), "project duplicate content") {
+		t.Fatalf("project report missing duplicate content:\n%s", string(content))
+	}
+}
+
+func TestOpenReconcileDBGlobalReadOnlyDoesNotCreateMissingDB(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "missing.db")
+	_, _, _, err := openReconcileDB("global", dbPath)
+	if err == nil {
+		t.Fatalf("openReconcileDB(global missing) error = nil, want error")
+	}
+	if _, statErr := os.Stat(dbPath); !os.IsNotExist(statErr) {
+		t.Fatalf("missing global db was created or stat failed: %v", statErr)
+	}
+}
+
+func TestOpenReconcileDBProjectReadOnlyDoesNotCreateMemoryDir(t *testing.T) {
+	t.Parallel()
+
+	projectDir := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(project) error = %v", err)
+	}
+	_, _, _, err := openReconcileDB("project="+projectDir, "")
+	if err == nil {
+		t.Fatalf("openReconcileDB(project missing) error = nil, want error")
+	}
+	memoryDir := filepath.Join(projectDir, ".memory")
+	if _, statErr := os.Stat(memoryDir); !os.IsNotExist(statErr) {
+		t.Fatalf("missing project .memory dir was created or stat failed: %v", statErr)
+	}
+}
+
+func TestOpenReconcileDBRejectsDBPathForProjectScope(t *testing.T) {
+	t.Parallel()
+
+	projectDir := filepath.Join(t.TempDir(), "project")
+	_, _, _, err := openReconcileDB("project="+projectDir, filepath.Join(t.TempDir(), "memory.db"))
+	if err == nil {
+		t.Fatalf("openReconcileDB(project with db path) error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "--db is only valid") {
+		t.Fatalf("openReconcileDB(project with db path) error = %v, want --db validation", err)
+	}
+}
+
+func TestParseReconcileSinceSupportsDays(t *testing.T) {
+	t.Parallel()
+
+	duration, err := parseReconcileSince("30d")
+	if err != nil {
+		t.Fatalf("parseReconcileSince(30d) error = %v", err)
+	}
+	if duration != 30*24*time.Hour {
+		t.Fatalf("duration = %s, want 720h", duration)
+	}
+	if _, err := parseReconcileSince("0d"); err == nil {
+		t.Fatalf("parseReconcileSince(0d) error = nil, want error")
+	}
+}
+
+func insertCLIRawObservation(t *testing.T, db *sql.DB, entityID int64, content string, createdAt time.Time) {
+	t.Helper()
+	var entityType sql.NullString
+	if err := db.QueryRow(`SELECT entity_type FROM entities WHERE id = ?`, entityID).Scan(&entityType); err != nil {
+		t.Fatalf("select entity type error = %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO observations (entity_id, content, source, confidence, entity_type, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		entityID,
+		content,
+		"test",
+		1.0,
+		nullableCLIString(entityType),
+		createdAt.UTC().Format("2006-01-02 15:04:05"),
+	); err != nil {
+		t.Fatalf("insert raw observation error = %v", err)
+	}
+}
+
+func nullableCLIString(value sql.NullString) any {
+	if !value.Valid {
+		return nil
+	}
+	return value.String
+}

--- a/cmd/workmem/reconcile.go
+++ b/cmd/workmem/reconcile.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"workmem/internal/mcpserver"
+	"workmem/internal/reconcile"
+	"workmem/internal/store"
+)
+
+func runReconcile(args []string) {
+	fs := flag.NewFlagSet("reconcile", flag.ExitOnError)
+	dbPath := fs.String("db", "", "path to the SQLite database file for global scope")
+	envFile := fs.String("env-file", "", "path to a .env file to load before running (process env wins over file values)")
+	mode := fs.String("mode", "propose", "reconcile mode (v0 supports propose only)")
+	scope := fs.String("scope", "global", "scan scope: global or project=<path>")
+	sinceRaw := fs.String("since", "30d", "scan window duration, e.g. 30d or 720h")
+	minObsPerEntity := fs.Int("min-obs-per-entity", 2, "minimum active observations per scanned entity")
+	maxEntitiesPerRun := fs.Int("max-entities-per-run", 50, "maximum entities to scan")
+	output := fs.String("output", "", "markdown report path (default: review/reconcile-<timestamp>.md)")
+	_ = fs.Parse(args)
+
+	loadEnvFile(*envFile)
+
+	if *mode != "propose" {
+		fmt.Fprintf(os.Stderr, "reconcile: unsupported --mode %q (v0 supports propose only)\n", *mode)
+		os.Exit(2)
+	}
+	if *minObsPerEntity <= 0 {
+		fmt.Fprintln(os.Stderr, "reconcile: --min-obs-per-entity must be > 0")
+		os.Exit(2)
+	}
+	if *maxEntitiesPerRun <= 0 {
+		fmt.Fprintln(os.Stderr, "reconcile: --max-entities-per-run must be > 0")
+		os.Exit(2)
+	}
+	since, err := parseReconcileSince(*sinceRaw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reconcile: invalid --since: %v\n", err)
+		os.Exit(2)
+	}
+
+	db, release, scopeLabel, err := openReconcileDB(*scope, *dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reconcile: %v\n", err)
+		os.Exit(1)
+	}
+	defer release()
+
+	report, err := store.BuildReconcileProposeReport(db, store.ReconcileProposeOptions{
+		GeneratedAt:       time.Now().UTC(),
+		Since:             since,
+		SinceLabel:        *sinceRaw,
+		MinObsPerEntity:   *minObsPerEntity,
+		MaxEntitiesPerRun: *maxEntitiesPerRun,
+		Scope:             scopeLabel,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reconcile: build propose report: %v\n", err)
+		os.Exit(1)
+	}
+	reportPath, err := reconcile.WriteProposeReport(*output, report)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reconcile: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("reconcile propose: wrote %s (%d exact duplicate group(s), %d candidate(s), 0 mutation(s))\n",
+		reportPath,
+		len(report.DuplicateGroups),
+		report.CandidatesProposed,
+	)
+}
+
+func openReconcileDB(scopeValue string, dbPath string) (*sql.DB, func(), string, error) {
+	scopeValue = strings.TrimSpace(scopeValue)
+	if scopeValue == "" || scopeValue == "global" {
+		resolved, err := mcpserver.ResolveDBPath(dbPath)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("resolve global db: %w", err)
+		}
+		db, err := store.OpenReadOnlyDB(resolved)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("open global db read-only: %w", err)
+		}
+		return db, func() { _ = db.Close() }, "global", nil
+	}
+	const projectPrefix = "project="
+	if !strings.HasPrefix(scopeValue, projectPrefix) {
+		return nil, nil, "", fmt.Errorf("invalid --scope %q (use global or project=<path>)", scopeValue)
+	}
+	project := strings.TrimSpace(strings.TrimPrefix(scopeValue, projectPrefix))
+	if project == "" {
+		return nil, nil, "", fmt.Errorf("invalid --scope %q: project path is empty", scopeValue)
+	}
+	if strings.TrimSpace(dbPath) != "" {
+		return nil, nil, "", fmt.Errorf("--db is only valid with --scope global")
+	}
+	resolved, projectDBPath := store.ResolveProjectDBPath(project, "")
+	db, err := store.OpenReadOnlyDB(projectDBPath)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("open project db read-only: %w", err)
+	}
+	return db, func() { _ = db.Close() }, "project:" + resolved, nil
+}
+
+func parseReconcileSince(value string) (time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	if strings.HasSuffix(value, "d") {
+		daysText := strings.TrimSuffix(value, "d")
+		days, err := time.ParseDuration(daysText + "h")
+		if err != nil {
+			return 0, fmt.Errorf("parse day count %q: %w", daysText, err)
+		}
+		duration := days * 24
+		if duration <= 0 {
+			return 0, fmt.Errorf("duration must be > 0")
+		}
+		return duration, nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, err
+	}
+	if duration <= 0 {
+		return 0, fmt.Errorf("duration must be > 0")
+	}
+	return duration, nil
+}

--- a/internal/reconcile/report.go
+++ b/internal/reconcile/report.go
@@ -1,0 +1,142 @@
+package reconcile
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"workmem/internal/store"
+)
+
+func DefaultReportPath(now time.Time) string {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return filepath.Join("review", fmt.Sprintf("reconcile-%s.md", now.UTC().Format("20060102-150405")))
+}
+
+func WriteProposeReport(path string, report *store.ReconcileProposeReport) (string, error) {
+	if report == nil {
+		return "", fmt.Errorf("write reconcile report: nil report")
+	}
+	if strings.TrimSpace(path) == "" {
+		path = DefaultReportPath(report.GeneratedAt)
+	}
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return "", fmt.Errorf("create reconcile report dir: %w", err)
+		}
+	}
+	content := RenderProposeReport(report)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return "", fmt.Errorf("write reconcile report: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return "", fmt.Errorf("harden reconcile report mode: %w", err)
+	}
+	return path, nil
+}
+
+func RenderProposeReport(report *store.ReconcileProposeReport) string {
+	var buf bytes.Buffer
+	generatedAt := report.GeneratedAt.UTC()
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+	fmt.Fprintf(&buf, "# Reconcile Run - %s\n\n", generatedAt.Format(time.RFC3339))
+	fmt.Fprintf(&buf, "Mode: %s\n", report.Mode)
+	fmt.Fprintf(&buf, "Scope: %s\n", report.Scope)
+	sinceLabel := strings.TrimSpace(report.SinceLabel)
+	if sinceLabel == "" {
+		sinceLabel = report.Since.String()
+	}
+	fmt.Fprintf(&buf, "Since: %s\n\n", sinceLabel)
+
+	fmt.Fprintf(&buf, "## Summary\n")
+	fmt.Fprintf(&buf, "- Entities scanned: %d\n", len(report.ScannedEntities))
+	fmt.Fprintf(&buf, "- Exact duplicate groups: %d\n", len(report.DuplicateGroups))
+	fmt.Fprintf(&buf, "- Candidates proposed: %d\n", report.CandidatesProposed)
+	fmt.Fprintf(&buf, "- Mutations applied: 0\n\n")
+
+	fmt.Fprintf(&buf, "## Exact duplicate candidates\n\n")
+	if len(report.DuplicateGroups) == 0 {
+		fmt.Fprintf(&buf, "No exact duplicate candidates found.\n\n")
+	} else {
+		fmt.Fprintf(&buf, "| Entity | Content | Target obs | Source obs | Action | Rationale |\n")
+		fmt.Fprintf(&buf, "|---|---|---:|---:|---|---|\n")
+		for _, group := range report.DuplicateGroups {
+			action := group.Action
+			if action == "" {
+				action = store.ReconcileActionProposed
+			}
+			rationale := group.Rationale
+			if rationale == "" {
+				rationale = store.ReconcileRationaleExactDuplicateSameEntity
+			}
+			for _, source := range group.Sources {
+				fmt.Fprintf(&buf, "| %s | %s | %d | %d | %s | %s |\n",
+					markdownCell(group.EntityName),
+					markdownCell(truncateString(group.Content, 96)),
+					group.Target.ID,
+					source.ID,
+					markdownCell(action),
+					markdownCell(rationale),
+				)
+			}
+		}
+		fmt.Fprintf(&buf, "\n")
+	}
+
+	fmt.Fprintf(&buf, "## Hygiene signals\n\n")
+	if len(report.ScannedEntities) == 0 {
+		fmt.Fprintf(&buf, "No entities matched the scan window.\n")
+	} else {
+		fmt.Fprintf(&buf, "| Entity | Active observations | Recent observations | Last observation |\n")
+		fmt.Fprintf(&buf, "|---|---:|---:|---|\n")
+		for _, signal := range report.ScannedEntities {
+			fmt.Fprintf(&buf, "| %s | %d | %d | %s |\n",
+				markdownCell(signal.Name),
+				signal.ActiveObservations,
+				signal.RecentObservations,
+				markdownCell(signal.LastObservationAt),
+			)
+		}
+	}
+	return buf.String()
+}
+
+func markdownCell(value string) string {
+	value = html.EscapeString(value)
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "|", `\|`)
+	value = strings.ReplaceAll(value, "`", "\\`")
+	value = strings.ReplaceAll(value, "*", "\\*")
+	value = strings.ReplaceAll(value, "_", "\\_")
+	value = strings.ReplaceAll(value, "[", "\\[")
+	value = strings.ReplaceAll(value, "]", "\\]")
+	value = strings.ReplaceAll(value, "(", "\\(")
+	value = strings.ReplaceAll(value, ")", "\\)")
+	value = strings.ReplaceAll(value, "!", "\\!")
+	return strings.TrimSpace(value)
+}
+
+func truncateString(value string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(value) <= maxRunes {
+		return value
+	}
+	runes := []rune(value)
+	if maxRunes <= 3 {
+		return string(runes[:maxRunes])
+	}
+	return string(runes[:maxRunes-3]) + "..."
+}

--- a/internal/reconcile/report.go
+++ b/internal/reconcile/report.go
@@ -43,6 +43,9 @@ func WriteProposeReport(path string, report *store.ReconcileProposeReport) (stri
 }
 
 func RenderProposeReport(report *store.ReconcileProposeReport) string {
+	if report == nil {
+		return ""
+	}
 	var buf bytes.Buffer
 	generatedAt := report.GeneratedAt.UTC()
 	if generatedAt.IsZero() {

--- a/internal/reconcile/report_test.go
+++ b/internal/reconcile/report_test.go
@@ -1,0 +1,105 @@
+package reconcile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"workmem/internal/store"
+)
+
+func TestRenderProposeReportIncludesSummaryAndEscapesCells(t *testing.T) {
+	report := &store.ReconcileProposeReport{
+		GeneratedAt:        time.Date(2026, 5, 2, 8, 0, 0, 0, time.UTC),
+		Mode:               "propose",
+		Scope:              "global",
+		Since:              30 * 24 * time.Hour,
+		SinceLabel:         "30d",
+		CandidatesProposed: 1,
+		ScannedEntities: []store.ReconcileEntitySignal{{
+			EntityID:           1,
+			Name:               "Entity|One<script>",
+			ActiveObservations: 2,
+			RecentObservations: 2,
+			LastObservationAt:  "2026-05-02 08:00:00",
+		}},
+		DuplicateGroups: []store.ReconcileDuplicateGroup{{
+			EntityID:   1,
+			EntityName: "Entity|One<script>",
+			Content:    "duplicate | [link](x) ![img](y) *bold* `code`",
+			Target:     store.ReconcileObservation{ID: 20},
+			Sources:    []store.ReconcileObservation{{ID: 10}},
+		}},
+	}
+
+	rendered := RenderProposeReport(report)
+	for _, want := range []string{
+		"Mode: propose",
+		"Since: 30d",
+		"- Entities scanned: 1",
+		"- Candidates proposed: 1",
+		"Entity\\|One&lt;script&gt;",
+		"duplicate \\| \\[link\\]\\(x\\) \\!\\[img\\]\\(y\\) \\*bold\\* \\`code\\`",
+		"| Entity | Content | Target obs | Source obs | Action | Rationale |",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered report missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestWriteProposeReportCreatesPrivateMarkdownFile(t *testing.T) {
+	report := &store.ReconcileProposeReport{
+		GeneratedAt: time.Date(2026, 5, 2, 8, 0, 0, 0, time.UTC),
+		Mode:        "propose",
+		Scope:       "global",
+		Since:       time.Hour,
+	}
+	path := filepath.Join(t.TempDir(), "nested", "report.md")
+	written, err := WriteProposeReport(path, report)
+	if err != nil {
+		t.Fatalf("WriteProposeReport() error = %v", err)
+	}
+	if written != path {
+		t.Fatalf("written path = %q, want %q", written, path)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(report) error = %v", err)
+	}
+	if !strings.Contains(string(content), "# Reconcile Run") {
+		t.Fatalf("report content missing heading: %s", string(content))
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(report) error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("report mode = %v, want 0600", got)
+	}
+}
+
+func TestWriteProposeReportHardensExistingMarkdownFile(t *testing.T) {
+	report := &store.ReconcileProposeReport{
+		GeneratedAt: time.Date(2026, 5, 2, 8, 0, 0, 0, time.UTC),
+		Mode:        "propose",
+		Scope:       "global",
+		Since:       time.Hour,
+	}
+	path := filepath.Join(t.TempDir(), "existing-report.md")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("WriteFile(existing) error = %v", err)
+	}
+	if _, err := WriteProposeReport(path, report); err != nil {
+		t.Fatalf("WriteProposeReport(existing) error = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(existing report) error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("existing report mode = %v, want 0600", got)
+	}
+}

--- a/internal/reconcile/report_test.go
+++ b/internal/reconcile/report_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -72,13 +73,7 @@ func TestWriteProposeReportCreatesPrivateMarkdownFile(t *testing.T) {
 	if !strings.Contains(string(content), "# Reconcile Run") {
 		t.Fatalf("report content missing heading: %s", string(content))
 	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("Stat(report) error = %v", err)
-	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("report mode = %v, want 0600", got)
-	}
+	assertReportMode0600(t, path)
 }
 
 func TestWriteProposeReportHardensExistingMarkdownFile(t *testing.T) {
@@ -95,11 +90,19 @@ func TestWriteProposeReportHardensExistingMarkdownFile(t *testing.T) {
 	if _, err := WriteProposeReport(path, report); err != nil {
 		t.Fatalf("WriteProposeReport(existing) error = %v", err)
 	}
+	assertReportMode0600(t, path)
+}
+
+func assertReportMode0600(t *testing.T, path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not portable on Windows")
+	}
 	info, err := os.Stat(path)
 	if err != nil {
-		t.Fatalf("Stat(existing report) error = %v", err)
+		t.Fatalf("Stat(report) error = %v", err)
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("existing report mode = %v, want 0600", got)
+		t.Fatalf("report mode = %v, want 0600", got)
 	}
 }

--- a/internal/reconcile/report_test.go
+++ b/internal/reconcile/report_test.go
@@ -51,6 +51,12 @@ func TestRenderProposeReportIncludesSummaryAndEscapesCells(t *testing.T) {
 	}
 }
 
+func TestRenderProposeReportNilReturnsEmptyString(t *testing.T) {
+	if got := RenderProposeReport(nil); got != "" {
+		t.Fatalf("RenderProposeReport(nil) = %q, want empty string", got)
+	}
+}
+
 func TestWriteProposeReportCreatesPrivateMarkdownFile(t *testing.T) {
 	report := &store.ReconcileProposeReport{
 		GeneratedAt: time.Date(2026, 5, 2, 8, 0, 0, 0, time.UTC),

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -13,13 +13,25 @@ func activeEventSQL(alias string) string {
 	return fmt.Sprintf(`(%s.expires_at IS NULL OR datetime(%s.expires_at) > CURRENT_TIMESTAMP)`, alias, alias)
 }
 
+func activeEventAsOfSQL(alias string) string {
+	return fmt.Sprintf(`(%s.expires_at IS NULL OR datetime(%s.expires_at) > datetime(?))`, alias, alias)
+}
+
 func activeObservationSQL(alias string) string {
+	return activeObservationWithEventSQL(alias, activeEventSQL("ev_active"))
+}
+
+func activeObservationAsOfSQL(alias string) string {
+	return activeObservationWithEventSQL(alias, activeEventAsOfSQL("ev_active"))
+}
+
+func activeObservationWithEventSQL(alias string, eventPredicate string) string {
 	return fmt.Sprintf(`%s.deleted_at IS NULL AND %s.superseded_by IS NULL AND (
 		%s.event_id IS NULL OR EXISTS (
 			SELECT 1 FROM events ev_active
 			WHERE ev_active.id = %s.event_id AND %s
 		)
-	)`, alias, alias, alias, alias, activeEventSQL("ev_active"))
+	)`, alias, alias, alias, alias, eventPredicate)
 }
 
 func normalizeExpiresAt(value string) (any, error) {

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -15,6 +15,11 @@ var (
 	projectDBLRU = list.New()
 )
 
+const (
+	projectMemoryDirName = ".memory"
+	projectMemoryDBName  = "memory.db"
+)
+
 type projectDBEntry struct {
 	db   *sql.DB
 	refs int
@@ -37,6 +42,11 @@ func ResolveProjectPath(project string, homedir string) string {
 	return filepath.Join(homedir, project)
 }
 
+func ResolveProjectDBPath(project string, homedir string) (string, string) {
+	resolved := ResolveProjectPath(project, homedir)
+	return resolved, filepath.Join(resolved, projectMemoryDirName, projectMemoryDBName)
+}
+
 // AcquireDB returns the global DB for empty project scope or a leased project
 // DB handle for project scope. Callers must invoke the returned release
 // function once they are done with the handle so idle project handles can be
@@ -47,7 +57,7 @@ func AcquireDB(defaultDB *sql.DB, project string) (*sql.DB, func(), error) {
 		return defaultDB, func() {}, nil
 	}
 
-	resolved := ResolveProjectPath(project, "")
+	resolved, dbPath := ResolveProjectDBPath(project, "")
 	projectDBMu.Lock()
 
 	if existing, ok := projectDBs[resolved]; ok {
@@ -57,7 +67,7 @@ func AcquireDB(defaultDB *sql.DB, project string) (*sql.DB, func(), error) {
 		return existing.db, projectDBRelease(resolved), nil
 	}
 
-	dbDir := filepath.Join(resolved, ".memory")
+	dbDir := filepath.Dir(dbPath)
 	created := false
 	if _, err := os.Stat(dbDir); err != nil {
 		if !os.IsNotExist(err) {
@@ -73,7 +83,6 @@ func AcquireDB(defaultDB *sql.DB, project string) (*sql.DB, func(), error) {
 	if created {
 		_ = os.Chmod(dbDir, 0o700)
 	}
-	dbPath := filepath.Join(dbDir, "memory.db")
 	db, err := InitDB(dbPath)
 	if err != nil {
 		projectDBMu.Unlock()

--- a/internal/store/reconcile.go
+++ b/internal/store/reconcile.go
@@ -10,6 +10,7 @@ import (
 const (
 	ReconcileActionProposed                    = "proposed"
 	ReconcileRationaleExactDuplicateSameEntity = "exact_duplicate_same_entity"
+	ReconcileMaxEntitiesPerRunLimit            = 900
 )
 
 type ReconcileProposeOptions struct {
@@ -83,6 +84,9 @@ func BuildReconcileProposeReport(db *sql.DB, options ReconcileProposeOptions) (*
 	maxEntitiesPerRun := options.MaxEntitiesPerRun
 	if maxEntitiesPerRun <= 0 {
 		maxEntitiesPerRun = 50
+	}
+	if maxEntitiesPerRun > ReconcileMaxEntitiesPerRunLimit {
+		return nil, fmt.Errorf("reconcile propose: max entities per run %d exceeds limit %d", maxEntitiesPerRun, ReconcileMaxEntitiesPerRunLimit)
 	}
 	scope := strings.TrimSpace(options.Scope)
 	if scope == "" {

--- a/internal/store/reconcile.go
+++ b/internal/store/reconcile.go
@@ -89,12 +89,13 @@ func BuildReconcileProposeReport(db *sql.DB, options ReconcileProposeOptions) (*
 		scope = "global"
 	}
 
+	asOf := now.UTC().Format(sqliteTimestampLayout)
 	cutoff := now.Add(-since).UTC().Format(sqliteTimestampLayout)
-	signals, err := selectReconcileEntitySignals(db, cutoff, minObsPerEntity, maxEntitiesPerRun)
+	signals, err := selectReconcileEntitySignals(db, cutoff, asOf, minObsPerEntity, maxEntitiesPerRun)
 	if err != nil {
 		return nil, err
 	}
-	groups, candidates, err := selectExactDuplicateGroups(db, signals)
+	groups, candidates, err := selectExactDuplicateGroups(db, signals, asOf)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +112,7 @@ func BuildReconcileProposeReport(db *sql.DB, options ReconcileProposeOptions) (*
 	}, nil
 }
 
-func selectReconcileEntitySignals(db *sql.DB, cutoff string, minObsPerEntity int, maxEntitiesPerRun int) ([]ReconcileEntitySignal, error) {
+func selectReconcileEntitySignals(db *sql.DB, cutoff string, asOf string, minObsPerEntity int, maxEntitiesPerRun int) ([]ReconcileEntitySignal, error) {
 	rows, err := db.Query(fmt.Sprintf(`
 		SELECT e.id, e.name, e.entity_type,
 		       COUNT(o.id) AS active_observations,
@@ -124,7 +125,7 @@ func selectReconcileEntitySignals(db *sql.DB, cutoff string, minObsPerEntity int
 		HAVING COUNT(o.id) >= ? AND SUM(CASE WHEN datetime(o.created_at) >= datetime(?) THEN 1 ELSE 0 END) > 0
 		ORDER BY datetime(last_observation_at) DESC, e.id DESC
 		LIMIT ?
-	`, activeObservationSQL("o")), cutoff, minObsPerEntity, cutoff, maxEntitiesPerRun)
+	`, activeObservationAsOfSQL("o")), cutoff, asOf, minObsPerEntity, cutoff, maxEntitiesPerRun)
 	if err != nil {
 		return nil, fmt.Errorf("select reconcile entity signals: %w", err)
 	}
@@ -146,7 +147,7 @@ func selectReconcileEntitySignals(db *sql.DB, cutoff string, minObsPerEntity int
 	return signals, nil
 }
 
-func selectExactDuplicateGroups(db *sql.DB, signals []ReconcileEntitySignal) ([]ReconcileDuplicateGroup, int, error) {
+func selectExactDuplicateGroups(db *sql.DB, signals []ReconcileEntitySignal, asOf string) ([]ReconcileDuplicateGroup, int, error) {
 	if len(signals) == 0 {
 		return nil, 0, nil
 	}
@@ -161,6 +162,7 @@ func selectExactDuplicateGroups(db *sql.DB, signals []ReconcileEntitySignal) ([]
 	for _, entityID := range entityIDs {
 		args = append(args, entityID)
 	}
+	args = append(args, asOf, asOf)
 
 	rows, err := db.Query(fmt.Sprintf(`
 		WITH duplicate_groups AS (
@@ -179,7 +181,7 @@ func selectExactDuplicateGroups(db *sql.DB, signals []ReconcileEntitySignal) ([]
 		JOIN entities e ON e.id = o.entity_id
 		WHERE e.deleted_at IS NULL AND %s
 		ORDER BY o.entity_id, o.content, datetime(o.created_at) DESC, o.id DESC
-	`, placeholders, activeObservationSQL("o"), activeObservationSQL("o")), args...)
+	`, placeholders, activeObservationAsOfSQL("o"), activeObservationAsOfSQL("o")), args...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("select exact duplicate observations: %w", err)
 	}
@@ -240,6 +242,16 @@ func selectExactDuplicateGroups(db *sql.DB, signals []ReconcileEntitySignal) ([]
 		candidates += len(group.Sources)
 	}
 	return groups, candidates, nil
+}
+
+func activeObservationAsOfSQL(alias string) string {
+	return fmt.Sprintf(`%s.deleted_at IS NULL AND %s.superseded_by IS NULL AND (
+		%s.event_id IS NULL OR EXISTS (
+			SELECT 1 FROM events ev_active
+			WHERE ev_active.id = %s.event_id
+			  AND (ev_active.expires_at IS NULL OR datetime(ev_active.expires_at) > datetime(?))
+		)
+	)`, alias, alias, alias, alias)
 }
 
 func nullableStringValue(value sql.NullString) string {

--- a/internal/store/reconcile.go
+++ b/internal/store/reconcile.go
@@ -1,0 +1,250 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	ReconcileActionProposed                    = "proposed"
+	ReconcileRationaleExactDuplicateSameEntity = "exact_duplicate_same_entity"
+)
+
+type ReconcileProposeOptions struct {
+	GeneratedAt       time.Time
+	Since             time.Duration
+	SinceLabel        string
+	MinObsPerEntity   int
+	MaxEntitiesPerRun int
+	Scope             string
+}
+
+type ReconcileProposeReport struct {
+	GeneratedAt        time.Time
+	Mode               string
+	Scope              string
+	Since              time.Duration
+	SinceLabel         string
+	ScannedEntities    []ReconcileEntitySignal
+	DuplicateGroups    []ReconcileDuplicateGroup
+	CandidatesProposed int
+}
+
+type ReconcileEntitySignal struct {
+	EntityID           int64
+	Name               string
+	EntityType         string
+	ActiveObservations int
+	RecentObservations int
+	LastObservationAt  string
+}
+
+type ReconcileDuplicateGroup struct {
+	EntityID   int64
+	EntityName string
+	EntityType string
+	Content    string
+	Action     string
+	Rationale  string
+	Target     ReconcileObservation
+	Sources    []ReconcileObservation
+}
+
+type ReconcileObservation struct {
+	ID         int64
+	Source     string
+	Confidence float64
+	EventID    *int64
+	CreatedAt  string
+}
+
+func BuildReconcileProposeReport(db *sql.DB, options ReconcileProposeOptions) (*ReconcileProposeReport, error) {
+	if db == nil {
+		return nil, fmt.Errorf("reconcile propose: nil db")
+	}
+	now := options.GeneratedAt
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	since := options.Since
+	if since <= 0 {
+		since = 30 * 24 * time.Hour
+	}
+	sinceLabel := strings.TrimSpace(options.SinceLabel)
+	if sinceLabel == "" {
+		sinceLabel = since.String()
+	}
+	minObsPerEntity := options.MinObsPerEntity
+	if minObsPerEntity <= 0 {
+		minObsPerEntity = 2
+	}
+	maxEntitiesPerRun := options.MaxEntitiesPerRun
+	if maxEntitiesPerRun <= 0 {
+		maxEntitiesPerRun = 50
+	}
+	scope := strings.TrimSpace(options.Scope)
+	if scope == "" {
+		scope = "global"
+	}
+
+	cutoff := now.Add(-since).UTC().Format(sqliteTimestampLayout)
+	signals, err := selectReconcileEntitySignals(db, cutoff, minObsPerEntity, maxEntitiesPerRun)
+	if err != nil {
+		return nil, err
+	}
+	groups, candidates, err := selectExactDuplicateGroups(db, signals)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReconcileProposeReport{
+		GeneratedAt:        now.UTC(),
+		Mode:               "propose",
+		Scope:              scope,
+		Since:              since,
+		SinceLabel:         sinceLabel,
+		ScannedEntities:    signals,
+		DuplicateGroups:    groups,
+		CandidatesProposed: candidates,
+	}, nil
+}
+
+func selectReconcileEntitySignals(db *sql.DB, cutoff string, minObsPerEntity int, maxEntitiesPerRun int) ([]ReconcileEntitySignal, error) {
+	rows, err := db.Query(fmt.Sprintf(`
+		SELECT e.id, e.name, e.entity_type,
+		       COUNT(o.id) AS active_observations,
+		       SUM(CASE WHEN datetime(o.created_at) >= datetime(?) THEN 1 ELSE 0 END) AS recent_observations,
+		       MAX(o.created_at) AS last_observation_at
+		FROM observations o
+		JOIN entities e ON e.id = o.entity_id
+		WHERE e.deleted_at IS NULL AND %s
+		GROUP BY e.id
+		HAVING COUNT(o.id) >= ? AND SUM(CASE WHEN datetime(o.created_at) >= datetime(?) THEN 1 ELSE 0 END) > 0
+		ORDER BY datetime(last_observation_at) DESC, e.id DESC
+		LIMIT ?
+	`, activeObservationSQL("o")), cutoff, minObsPerEntity, cutoff, maxEntitiesPerRun)
+	if err != nil {
+		return nil, fmt.Errorf("select reconcile entity signals: %w", err)
+	}
+	defer rows.Close()
+
+	signals := make([]ReconcileEntitySignal, 0)
+	for rows.Next() {
+		var signal ReconcileEntitySignal
+		var entityType sql.NullString
+		if err := rows.Scan(&signal.EntityID, &signal.Name, &entityType, &signal.ActiveObservations, &signal.RecentObservations, &signal.LastObservationAt); err != nil {
+			return nil, fmt.Errorf("scan reconcile entity signal: %w", err)
+		}
+		signal.EntityType = nullableStringValue(entityType)
+		signals = append(signals, signal)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate reconcile entity signals: %w", err)
+	}
+	return signals, nil
+}
+
+func selectExactDuplicateGroups(db *sql.DB, signals []ReconcileEntitySignal) ([]ReconcileDuplicateGroup, int, error) {
+	if len(signals) == 0 {
+		return nil, 0, nil
+	}
+	entityIDs := make([]int64, 0, len(signals))
+	entitySignals := make(map[int64]ReconcileEntitySignal, len(signals))
+	for _, signal := range signals {
+		entityIDs = append(entityIDs, signal.EntityID)
+		entitySignals[signal.EntityID] = signal
+	}
+	placeholders := placeholders(len(entityIDs))
+	args := make([]any, 0, len(entityIDs))
+	for _, entityID := range entityIDs {
+		args = append(args, entityID)
+	}
+
+	rows, err := db.Query(fmt.Sprintf(`
+		WITH duplicate_groups AS (
+			SELECT o.entity_id, o.content
+			FROM observations o
+			JOIN entities e ON e.id = o.entity_id
+			WHERE e.deleted_at IS NULL
+			  AND o.entity_id IN (%s)
+			  AND %s
+			GROUP BY o.entity_id, o.content
+			HAVING COUNT(o.id) > 1
+		)
+		SELECT o.id, o.entity_id, o.content, o.source, o.confidence, o.event_id, o.created_at
+		FROM observations o
+		JOIN duplicate_groups dg ON dg.entity_id = o.entity_id AND dg.content = o.content
+		JOIN entities e ON e.id = o.entity_id
+		WHERE e.deleted_at IS NULL AND %s
+		ORDER BY o.entity_id, o.content, datetime(o.created_at) DESC, o.id DESC
+	`, placeholders, activeObservationSQL("o"), activeObservationSQL("o")), args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("select exact duplicate observations: %w", err)
+	}
+	defer rows.Close()
+
+	groups := make([]ReconcileDuplicateGroup, 0)
+	var currentKey string
+	var current *ReconcileDuplicateGroup
+	for rows.Next() {
+		var entityID int64
+		var content string
+		var source sql.NullString
+		var confidence sql.NullFloat64
+		var eventID sql.NullInt64
+		var observation ReconcileObservation
+		if err := rows.Scan(&observation.ID, &entityID, &content, &source, &confidence, &eventID, &observation.CreatedAt); err != nil {
+			return nil, 0, fmt.Errorf("scan exact duplicate observation: %w", err)
+		}
+		observation.Source = nullableStringValue(source)
+		if confidence.Valid {
+			observation.Confidence = confidence.Float64
+		}
+		if eventID.Valid {
+			value := eventID.Int64
+			observation.EventID = &value
+		}
+
+		key := fmt.Sprintf("%d\x00%s", entityID, content)
+		if key != currentKey {
+			if current != nil {
+				groups = append(groups, *current)
+			}
+			signal := entitySignals[entityID]
+			currentKey = key
+			current = &ReconcileDuplicateGroup{
+				EntityID:   entityID,
+				EntityName: signal.Name,
+				EntityType: signal.EntityType,
+				Content:    content,
+				Action:     ReconcileActionProposed,
+				Rationale:  ReconcileRationaleExactDuplicateSameEntity,
+				Target:     observation,
+				Sources:    make([]ReconcileObservation, 0, 1),
+			}
+			continue
+		}
+		current.Sources = append(current.Sources, observation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate exact duplicate observations: %w", err)
+	}
+	if current != nil {
+		groups = append(groups, *current)
+	}
+
+	candidates := 0
+	for _, group := range groups {
+		candidates += len(group.Sources)
+	}
+	return groups, candidates, nil
+}
+
+func nullableStringValue(value sql.NullString) string {
+	if !value.Valid {
+		return ""
+	}
+	return value.String
+}

--- a/internal/store/reconcile.go
+++ b/internal/store/reconcile.go
@@ -188,7 +188,9 @@ func selectExactDuplicateGroups(db *sql.DB, signals []ReconcileEntitySignal, asO
 	defer rows.Close()
 
 	groups := make([]ReconcileDuplicateGroup, 0)
-	var currentKey string
+	var currentEntityID int64
+	var currentContent string
+	var hasCurrent bool
 	var current *ReconcileDuplicateGroup
 	for rows.Next() {
 		var entityID int64
@@ -209,13 +211,14 @@ func selectExactDuplicateGroups(db *sql.DB, signals []ReconcileEntitySignal, asO
 			observation.EventID = &value
 		}
 
-		key := fmt.Sprintf("%d\x00%s", entityID, content)
-		if key != currentKey {
+		if !hasCurrent || entityID != currentEntityID || content != currentContent {
 			if current != nil {
 				groups = append(groups, *current)
 			}
 			signal := entitySignals[entityID]
-			currentKey = key
+			hasCurrent = true
+			currentEntityID = entityID
+			currentContent = content
 			current = &ReconcileDuplicateGroup{
 				EntityID:   entityID,
 				EntityName: signal.Name,
@@ -242,16 +245,6 @@ func selectExactDuplicateGroups(db *sql.DB, signals []ReconcileEntitySignal, asO
 		candidates += len(group.Sources)
 	}
 	return groups, candidates, nil
-}
-
-func activeObservationAsOfSQL(alias string) string {
-	return fmt.Sprintf(`%s.deleted_at IS NULL AND %s.superseded_by IS NULL AND (
-		%s.event_id IS NULL OR EXISTS (
-			SELECT 1 FROM events ev_active
-			WHERE ev_active.id = %s.event_id
-			  AND (ev_active.expires_at IS NULL OR datetime(ev_active.expires_at) > datetime(?))
-		)
-	)`, alias, alias, alias, alias)
 }
 
 func nullableStringValue(value sql.NullString) string {

--- a/internal/store/reconcile_test.go
+++ b/internal/store/reconcile_test.go
@@ -150,6 +150,43 @@ func TestBuildReconcileProposeReportIncludesOlderSourcesForRecentEntities(t *tes
 	}
 }
 
+func TestBuildReconcileProposeReportUsesGeneratedAtAsEventExpiryAsOf(t *testing.T) {
+	db := newTestDB(t, "reconcile-as-of-expiry.db")
+	generatedAt := time.Now().UTC().Add(-2 * time.Hour)
+
+	entityID, err := UpsertEntity(db, "AsOfExpiryEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	eventID, err := CreateEvent(db, "As-of expiry duplicate", "", "test", "", "")
+	if err != nil {
+		t.Fatalf("CreateEvent() error = %v", err)
+	}
+	if _, err := db.Exec(`UPDATE events SET expires_at = ? WHERE id = ?`, generatedAt.Add(30*time.Minute).Format(sqliteTimestampLayout), eventID); err != nil {
+		t.Fatalf("expire event error = %v", err)
+	}
+	olderID := insertRawObservationForReconcileTest(t, db, entityID, "as-of duplicate content", generatedAt.Add(-10*time.Minute), eventID)
+	newerID := insertRawObservationForReconcileTest(t, db, entityID, "as-of duplicate content", generatedAt.Add(-5*time.Minute), eventID)
+
+	report, err := BuildReconcileProposeReport(db, ReconcileProposeOptions{
+		GeneratedAt:       generatedAt,
+		Since:             24 * time.Hour,
+		MinObsPerEntity:   2,
+		MaxEntitiesPerRun: 10,
+		Scope:             "global",
+	})
+	if err != nil {
+		t.Fatalf("BuildReconcileProposeReport() error = %v", err)
+	}
+	if len(report.DuplicateGroups) != 1 {
+		t.Fatalf("DuplicateGroups len = %d, want 1 as of generated_at: %#v", len(report.DuplicateGroups), report.DuplicateGroups)
+	}
+	group := report.DuplicateGroups[0]
+	if group.Target.ID != newerID || len(group.Sources) != 1 || group.Sources[0].ID != olderID {
+		t.Fatalf("group = %#v, want target %d source %d", group, newerID, olderID)
+	}
+}
+
 func insertRawObservationForReconcileTest(t *testing.T, db *sql.DB, entityID int64, content string, createdAt time.Time, eventID ...int64) int64 {
 	t.Helper()
 	var entityType sql.NullString

--- a/internal/store/reconcile_test.go
+++ b/internal/store/reconcile_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 	"time"
 )
@@ -147,6 +148,23 @@ func TestBuildReconcileProposeReportIncludesOlderSourcesForRecentEntities(t *tes
 	}
 	if len(group.Sources) != 1 || group.Sources[0].ID != olderID {
 		t.Fatalf("sources = %#v, want older source %d even outside since window", group.Sources, olderID)
+	}
+}
+
+func TestBuildReconcileProposeReportRejectsTooManyEntities(t *testing.T) {
+	db := newTestDB(t, "reconcile-entity-limit.db")
+	_, err := BuildReconcileProposeReport(db, ReconcileProposeOptions{
+		GeneratedAt:       time.Now().UTC(),
+		Since:             24 * time.Hour,
+		MinObsPerEntity:   2,
+		MaxEntitiesPerRun: ReconcileMaxEntitiesPerRunLimit + 1,
+		Scope:             "global",
+	})
+	if err == nil {
+		t.Fatalf("BuildReconcileProposeReport(over limit) error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Fatalf("BuildReconcileProposeReport(over limit) error = %v, want limit message", err)
 	}
 }
 

--- a/internal/store/reconcile_test.go
+++ b/internal/store/reconcile_test.go
@@ -1,0 +1,202 @@
+package store
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func TestBuildReconcileProposeReportFindsExactDuplicatesWithoutMutation(t *testing.T) {
+	db := newTestDB(t, "reconcile-propose.db")
+	now := time.Now().UTC()
+
+	entityID, err := UpsertEntity(db, "DuplicateEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity(duplicate) error = %v", err)
+	}
+	olderID := insertRawObservationForReconcileTest(t, db, entityID, "exact duplicate content", now.Add(-2*time.Hour))
+	newerID := insertRawObservationForReconcileTest(t, db, entityID, "exact duplicate content", now.Add(-1*time.Hour))
+	insertRawObservationForReconcileTest(t, db, entityID, "different content", now.Add(-30*time.Minute))
+
+	otherEntityID, err := UpsertEntity(db, "OtherEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity(other) error = %v", err)
+	}
+	insertRawObservationForReconcileTest(t, db, otherEntityID, "exact duplicate content", now.Add(-1*time.Hour))
+	insertRawObservationForReconcileTest(t, db, otherEntityID, "other unique content", now.Add(-30*time.Minute))
+
+	observationRowsBefore := countRowsForReconcileTest(t, db, "observations")
+	reconcileRowsBefore := countRowsForReconcileTest(t, db, "reconcile_runs")
+	decisionRowsBefore := countRowsForReconcileTest(t, db, "reconcile_decisions")
+
+	report, err := BuildReconcileProposeReport(db, ReconcileProposeOptions{
+		GeneratedAt:       now,
+		Since:             24 * time.Hour,
+		MinObsPerEntity:   2,
+		MaxEntitiesPerRun: 10,
+		Scope:             "global",
+	})
+	if err != nil {
+		t.Fatalf("BuildReconcileProposeReport() error = %v", err)
+	}
+
+	if countRowsForReconcileTest(t, db, "observations") != observationRowsBefore {
+		t.Fatalf("propose report mutated observations table")
+	}
+	if countRowsForReconcileTest(t, db, "reconcile_runs") != reconcileRowsBefore {
+		t.Fatalf("propose report inserted reconcile run rows")
+	}
+	if countRowsForReconcileTest(t, db, "reconcile_decisions") != decisionRowsBefore {
+		t.Fatalf("propose report inserted reconcile decision rows")
+	}
+	if got := sumAccessCountForReconcileTest(t, db); got != 0 {
+		t.Fatalf("propose report touched access_count = %d, want 0", got)
+	}
+	if len(report.DuplicateGroups) != 1 {
+		t.Fatalf("DuplicateGroups len = %d, want 1: %#v", len(report.DuplicateGroups), report.DuplicateGroups)
+	}
+	group := report.DuplicateGroups[0]
+	if group.EntityID != entityID {
+		t.Fatalf("duplicate group entity = %d, want %d", group.EntityID, entityID)
+	}
+	if group.Target.ID != newerID {
+		t.Fatalf("duplicate target = %d, want newest %d", group.Target.ID, newerID)
+	}
+	if group.Action != ReconcileActionProposed || group.Rationale != ReconcileRationaleExactDuplicateSameEntity {
+		t.Fatalf("duplicate metadata = (%q, %q), want proposed exact duplicate", group.Action, group.Rationale)
+	}
+	if len(group.Sources) != 1 || group.Sources[0].ID != olderID {
+		t.Fatalf("duplicate sources = %#v, want older %d", group.Sources, olderID)
+	}
+	if report.CandidatesProposed != 1 {
+		t.Fatalf("CandidatesProposed = %d, want 1", report.CandidatesProposed)
+	}
+}
+
+func TestBuildReconcileProposeReportIgnoresInactiveDuplicates(t *testing.T) {
+	db := newTestDB(t, "reconcile-inactive.db")
+	now := time.Now().UTC()
+
+	entityID, err := UpsertEntity(db, "InactiveDuplicateEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	activeID := insertRawObservationForReconcileTest(t, db, entityID, "inactive duplicate content", now.Add(-1*time.Hour))
+	deletedID := insertRawObservationForReconcileTest(t, db, entityID, "inactive duplicate content", now.Add(-2*time.Hour))
+	if _, err := db.Exec(`UPDATE observations SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`, deletedID); err != nil {
+		t.Fatalf("tombstone duplicate error = %v", err)
+	}
+	targetID := insertRawObservationForReconcileTest(t, db, entityID, "superseded duplicate content", now.Add(-1*time.Hour))
+	sourceID := insertRawObservationForReconcileTest(t, db, entityID, "superseded duplicate content", now.Add(-2*time.Hour))
+	markObservationSupersededForTest(t, db, sourceID, targetID, "test_supersession")
+	expiredEventID, err := CreateEvent(db, "Expired reconcile duplicate", "", "test", "", "")
+	if err != nil {
+		t.Fatalf("CreateEvent() error = %v", err)
+	}
+	expiredID := insertRawObservationForReconcileTest(t, db, entityID, "event duplicate content", now.Add(-2*time.Hour), expiredEventID)
+	insertRawObservationForReconcileTest(t, db, entityID, "event duplicate content", now.Add(-1*time.Hour))
+	if _, err := db.Exec(`UPDATE events SET expires_at = ? WHERE id = ?`, now.Add(-30*time.Minute).Format(sqliteTimestampLayout), expiredEventID); err != nil {
+		t.Fatalf("expire event error = %v", err)
+	}
+	if activeID == 0 || expiredID == 0 {
+		t.Fatalf("seed ids unexpectedly zero")
+	}
+
+	report, err := BuildReconcileProposeReport(db, ReconcileProposeOptions{
+		GeneratedAt:       now,
+		Since:             24 * time.Hour,
+		MinObsPerEntity:   2,
+		MaxEntitiesPerRun: 10,
+		Scope:             "global",
+	})
+	if err != nil {
+		t.Fatalf("BuildReconcileProposeReport() error = %v", err)
+	}
+	if len(report.DuplicateGroups) != 0 {
+		t.Fatalf("inactive duplicates produced groups: %#v", report.DuplicateGroups)
+	}
+}
+
+func TestBuildReconcileProposeReportIncludesOlderSourcesForRecentEntities(t *testing.T) {
+	db := newTestDB(t, "reconcile-since-boundary.db")
+	now := time.Now().UTC()
+
+	entityID, err := UpsertEntity(db, "SinceBoundaryEntity", "test")
+	if err != nil {
+		t.Fatalf("UpsertEntity() error = %v", err)
+	}
+	olderID := insertRawObservationForReconcileTest(t, db, entityID, "old source duplicate", now.Add(-45*24*time.Hour))
+	newerID := insertRawObservationForReconcileTest(t, db, entityID, "old source duplicate", now.Add(-1*time.Hour))
+
+	report, err := BuildReconcileProposeReport(db, ReconcileProposeOptions{
+		GeneratedAt:       now,
+		Since:             24 * time.Hour,
+		MinObsPerEntity:   2,
+		MaxEntitiesPerRun: 10,
+		Scope:             "global",
+	})
+	if err != nil {
+		t.Fatalf("BuildReconcileProposeReport() error = %v", err)
+	}
+	if len(report.DuplicateGroups) != 1 {
+		t.Fatalf("DuplicateGroups len = %d, want 1: %#v", len(report.DuplicateGroups), report.DuplicateGroups)
+	}
+	group := report.DuplicateGroups[0]
+	if group.EntityID != entityID || group.Target.ID != newerID {
+		t.Fatalf("group = %#v, want entity %d target %d", group, entityID, newerID)
+	}
+	if len(group.Sources) != 1 || group.Sources[0].ID != olderID {
+		t.Fatalf("sources = %#v, want older source %d even outside since window", group.Sources, olderID)
+	}
+}
+
+func insertRawObservationForReconcileTest(t *testing.T, db *sql.DB, entityID int64, content string, createdAt time.Time, eventID ...int64) int64 {
+	t.Helper()
+	var entityType sql.NullString
+	if err := db.QueryRow(`SELECT entity_type FROM entities WHERE id = ?`, entityID).Scan(&entityType); err != nil {
+		t.Fatalf("select entity type error = %v", err)
+	}
+	var eventValue any
+	if len(eventID) > 0 && eventID[0] > 0 {
+		eventValue = eventID[0]
+	}
+	result, err := db.Exec(
+		`INSERT INTO observations (entity_id, content, source, confidence, event_id, entity_type, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		entityID,
+		content,
+		"test",
+		1.0,
+		eventValue,
+		nullableString(entityType.String, ""),
+		createdAt.UTC().Format(sqliteTimestampLayout),
+	)
+	if err != nil {
+		t.Fatalf("insert raw observation error = %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("raw observation LastInsertId error = %v", err)
+	}
+	return id
+}
+
+func countRowsForReconcileTest(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM ` + table).Scan(&count); err != nil {
+		t.Fatalf("count %s error = %v", table, err)
+	}
+	return count
+}
+
+func sumAccessCountForReconcileTest(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var sum sql.NullInt64
+	if err := db.QueryRow(`SELECT SUM(access_count) FROM observations`).Scan(&sum); err != nil {
+		t.Fatalf("sum access_count error = %v", err)
+	}
+	if !sum.Valid {
+		return 0
+	}
+	return int(sum.Int64)
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -304,6 +304,27 @@ func openSQLite(dbPath string) (*sql.DB, error) {
 	return db, nil
 }
 
+func OpenReadOnlyDB(dbPath string) (*sql.DB, error) {
+	cleanPath := filepath.Clean(dbPath)
+	if _, err := os.Stat(cleanPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("memory db does not exist: %s", cleanPath)
+		}
+		return nil, fmt.Errorf("stat memory db: %w", err)
+	}
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=foreign_keys(1)", cleanPath)
+	db, err := sql.Open(sqliteDriverName, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open read-only sqlite: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("ping read-only sqlite: %w", err)
+	}
+	return db, nil
+}
+
 func InitDB(dbPath string) (*sql.DB, error) {
 	db, err := openSQLite(dbPath)
 	if err != nil {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -305,10 +305,11 @@ func openSQLite(dbPath string) (*sql.DB, error) {
 }
 
 func OpenReadOnlyDB(dbPath string) (*sql.DB, error) {
-	if strings.TrimSpace(dbPath) == "" {
+	trimmedPath := strings.TrimSpace(dbPath)
+	if trimmedPath == "" {
 		return nil, fmt.Errorf("memory db path is empty")
 	}
-	cleanPath := filepath.Clean(dbPath)
+	cleanPath := filepath.Clean(trimmedPath)
 	info, err := os.Stat(cleanPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -320,7 +320,7 @@ func OpenReadOnlyDB(dbPath string) (*sql.DB, error) {
 	if !info.Mode().IsRegular() {
 		return nil, fmt.Errorf("memory db path is not a regular file: %s", cleanPath)
 	}
-	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=foreign_keys(1)", cleanPath)
+	dsn := fmt.Sprintf("%s?mode=ro&_pragma=foreign_keys(1)", sqliteFileURI(cleanPath))
 	db, err := sql.Open(sqliteDriverName, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open read-only sqlite: %w", err)
@@ -331,6 +331,15 @@ func OpenReadOnlyDB(dbPath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("ping read-only sqlite: %w", err)
 	}
 	return db, nil
+}
+
+func sqliteFileURI(path string) string {
+	escapedPath := strings.NewReplacer(
+		"%", "%25",
+		"?", "%3F",
+		"#", "%23",
+	).Replace(filepath.ToSlash(path))
+	return "file:" + escapedPath
 }
 
 func InitDB(dbPath string) (*sql.DB, error) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -305,12 +305,19 @@ func openSQLite(dbPath string) (*sql.DB, error) {
 }
 
 func OpenReadOnlyDB(dbPath string) (*sql.DB, error) {
+	if strings.TrimSpace(dbPath) == "" {
+		return nil, fmt.Errorf("memory db path is empty")
+	}
 	cleanPath := filepath.Clean(dbPath)
-	if _, err := os.Stat(cleanPath); err != nil {
+	info, err := os.Stat(cleanPath)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("memory db does not exist: %s", cleanPath)
 		}
 		return nil, fmt.Errorf("stat memory db: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("memory db path is not a regular file: %s", cleanPath)
 	}
 	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=foreign_keys(1)", cleanPath)
 	db, err := sql.Open(sqliteDriverName, dsn)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -92,6 +92,27 @@ func TestOpenReadOnlyDBRejectsEmptyAndDirectoryPaths(t *testing.T) {
 	}
 }
 
+func TestOpenReadOnlyDBTrimsPathWhitespace(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "readonly-trim.db")
+	db, err := InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close(seed db) error = %v", err)
+	}
+
+	readOnly, err := OpenReadOnlyDB("  " + dbPath + "  ")
+	if err != nil {
+		t.Fatalf("OpenReadOnlyDB(padded path) error = %v", err)
+	}
+	if err := readOnly.Close(); err != nil {
+		t.Fatalf("Close(read-only db) error = %v", err)
+	}
+}
+
 func TestInitDBHardensSQLiteSidecarFiles(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX file modes are not portable on Windows")

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -113,12 +113,26 @@ func TestOpenReadOnlyDBTrimsPathWhitespace(t *testing.T) {
 	}
 }
 
+func TestSQLiteFileURIEscapesReservedCharacters(t *testing.T) {
+	t.Parallel()
+
+	got := sqliteFileURI(filepath.Join("dir", "readonly?fragment#percent%.db"))
+	want := "file:dir/readonly%3Ffragment%23percent%25.db"
+	if got != want {
+		t.Fatalf("sqliteFileURI() = %q, want %q", got, want)
+	}
+}
+
 func TestOpenReadOnlyDBEscapesURIReservedPathCharacters(t *testing.T) {
 	t.Parallel()
 
 	tmp := t.TempDir()
 	plainPath := filepath.Join(tmp, "plain.db")
-	reservedPath := filepath.Join(tmp, "readonly?fragment#percent%.db")
+	reservedName := "readonly?fragment#percent%.db"
+	if runtime.GOOS == "windows" {
+		reservedName = "readonly#percent%.db"
+	}
+	reservedPath := filepath.Join(tmp, reservedName)
 	db, err := InitDB(plainPath)
 	if err != nil {
 		t.Fatalf("InitDB() error = %v", err)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -81,6 +81,17 @@ func TestInitDBCreatesPrivateDatabaseFile(t *testing.T) {
 	}
 }
 
+func TestOpenReadOnlyDBRejectsEmptyAndDirectoryPaths(t *testing.T) {
+	t.Parallel()
+
+	if _, err := OpenReadOnlyDB("  "); err == nil {
+		t.Fatalf("OpenReadOnlyDB(empty) error = nil, want error")
+	}
+	if _, err := OpenReadOnlyDB(t.TempDir()); err == nil {
+		t.Fatalf("OpenReadOnlyDB(directory) error = nil, want error")
+	}
+}
+
 func TestInitDBHardensSQLiteSidecarFiles(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX file modes are not portable on Windows")

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -113,6 +113,37 @@ func TestOpenReadOnlyDBTrimsPathWhitespace(t *testing.T) {
 	}
 }
 
+func TestOpenReadOnlyDBEscapesURIReservedPathCharacters(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	plainPath := filepath.Join(tmp, "plain.db")
+	reservedPath := filepath.Join(tmp, "readonly?fragment#percent%.db")
+	db, err := InitDB(plainPath)
+	if err != nil {
+		t.Fatalf("InitDB() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close(seed db) error = %v", err)
+	}
+	if err := os.Rename(plainPath, reservedPath); err != nil {
+		t.Fatalf("Rename(seed db) error = %v", err)
+	}
+
+	readOnly, err := OpenReadOnlyDB(reservedPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnlyDB(reserved path) error = %v", err)
+	}
+	defer readOnly.Close()
+	var tableName string
+	if err := readOnly.QueryRow(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'entities'`).Scan(&tableName); err != nil {
+		t.Fatalf("query read-only reserved path db error = %v", err)
+	}
+	if tableName != "entities" {
+		t.Fatalf("tableName = %q, want entities", tableName)
+	}
+}
+
 func TestInitDBHardensSQLiteSidecarFiles(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX file modes are not portable on Windows")


### PR DESCRIPTION
## Summary
- Add `workmem reconcile --mode propose` for read-only exact-duplicate hygiene reports.
- Support global and project scopes through read-only DB handles that do not create missing DBs or audit rows.
- Render private markdown reports with hardened cell escaping and update the reconcile/docs contract.

## Validation
- `go test ./...`
- `git diff --check`
- Tripartite local review + follow-up review completed; blocker findings addressed before commit.