### PR TITLE
docs: clarify semantic reconcile next step

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@ Eight ordinary tables plus the contentless FTS table. Soft-delete via `deleted_a
 - `observation_embeddings` — optional semantic reconcile vectors keyed by observation, provider, endpoint key, model, and dimensions
 - `schema_migrations` — version registry for schema upgrades (`version`, `applied_at`)
 
-Semantic reconcile is validation/substrate-only. It does not generate candidates or reports yet. Exact-duplicate reconcile remains the only mutation path; remote embedding endpoints require the explicit `--allow-remote-embeddings` flag, not env/config alone.
+Semantic reconcile is validation/substrate-only today. It does not generate candidates or reports yet. Future semantic report mode must be read-only for observations, supersession fields, reconcile audit rows, access counts, and FTS state; embedding-cache writes are the only acceptable semantic-side persistence. Exact-duplicate reconcile remains the only mutation path; remote embedding endpoints require the explicit `--allow-remote-embeddings` flag, not env/config alone.
 
 **Invariant:** every query that reads live data **must** guard entity tombstones, observation tombstones, observation supersession (`superseded_by IS NULL`), and event expiry (`events.expires_at`). Missing any guard is a lifecycle bypass bug.
 

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -183,3 +183,10 @@ reports, call embedding endpoints, open a memory database, or mutate memory.
   observation deletion is soft-delete and SQLite FK cascade does not run there.
 - Semantic apply is not part of this contract. Exact-duplicate apply remains the
   only reconcile mutation path.
+
+Future semantic candidate reporting must be introduced as an explicit contract
+extension. Until that lands, `workmem reconcile semantic` remains validation-only.
+When report-only semantic mode is added, it must remain read-only with respect to
+observations, supersession fields, reconcile audit rows, access counts, and FTS
+state; embedding-cache writes are the only acceptable semantic-side persistence
+and must remain keyed by provider, endpoint key, model, and dimensions.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -112,6 +112,13 @@ outside the product path until reports provide evidence for thresholds. Since
 observations are tombstoned rather than hard-deleted, `forget` explicitly removes
 embedding rows instead of relying on foreign-key cascade cleanup.
 
+The next semantic step is report-only candidate generation. That orchestration
+must stay outside `internal/store`: store owns persistence primitives and
+lifecycle predicates, while semantic report behavior should compose those
+primitives with `internal/embedding` and `internal/reconcile` rendering. Semantic
+apply remains out of architecture until report false-positive rates are proven
+boring.
+
 ### Project isolation
 
 Global memory and project memory must remain physically and logically separate.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -319,12 +319,12 @@ restores active visibility and audit rows show what changed.
 Pulse before PR merge. Review focus: rollback fail-closed behavior, audit row
 completeness, and no semantic/non-deterministic matching sneaking into v0.
 
-## Phase 7: Semantic reconcile substrate [✅]
+## Phase 7: Semantic reconcile [🔧]
 
 Prepare semantic reconciliation without allowing semantic mutations. This phase
 keeps the v0 safety posture intact: deterministic exact-duplicate apply remains
-the only reconcile mutation path; semantic work remains validation/substrate-only
-until a separate report-only proposal step is reviewed.
+the only reconcile mutation path. Semantic work advances in two gates: first a
+validation/storage substrate, then a separate report-only candidate step.
 
 ### Step 7.1: Embedding storage and provider boundary [✅]
 
@@ -347,3 +347,31 @@ apply path exists.
 **On Step Gate (all items [x]):** focused security/correctness review. Review
 focus: no accidental remote memory export, no semantic apply route, and storage
 schema supports provider/model/dimension changes.
+
+### Step 7.2: Semantic report-only candidates [⏸]
+
+Generate semantic supersession candidates without mutating memory. This step may
+call explicitly configured local embedding providers and may populate
+`observation_embeddings`, but it must not add a semantic apply path.
+**Gate:** `workmem reconcile semantic --mode report` produces a markdown report
+for same-entity semantic candidates, validates provider/model/dimension/cache
+compatibility, and proves no observation/audit mutation occurs.
+
+- [ ] Add a local embedding client for `openai-compatible` and `ollama` providers
+- [ ] Populate/read `observation_embeddings` using provider, endpoint key, model,
+  and dimensions as the cache identity
+- [ ] Restrict semantic candidate generation to same-entity active observations
+  and exclude deleted, expired, or superseded observations
+- [ ] Render a markdown report under ignored `review/` with candidate pairs,
+  similarity, source/target IDs, provider/model/dimensions, and explicit
+  no-apply warning
+- [ ] Keep remote providers fail-closed unless `--allow-remote-embeddings` is
+  present on the CLI invocation
+- [ ] Prove `--mode report` does not mutate observations, supersession fields,
+  reconcile audit rows, access counts, or FTS state
+- [ ] Update `API_CONTRACT.md`, `ARCHITECTURE.md`, `OPERATIONS.md`, README, and
+  GitHub review instructions for the new report-only mode
+
+**On Step Gate (all items [x]):** tripartite review with security and
+correctness emphasis. Review focus: no accidental remote memory export, no
+semantic apply route, no lifecycle-guard bypass, and no cache identity drift.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -59,6 +59,11 @@
   decision.
 - Semantic reconcile has no apply route. Exact-duplicate apply remains the only
   reconcile mutation path until semantic reports prove thresholds are safe.
+- Semantic candidate reporting is a separate future gate. Until that gate lands,
+  `workmem reconcile semantic` remains validation-only. When report mode is
+  introduced, it must be read-only for observations, supersession fields,
+  reconcile audit rows, access counts, and FTS state; embedding-cache writes are
+  the only allowed semantic-side persistence.
 - `forget` must explicitly delete `observation_embeddings` rows for tombstoned
   observations/entities; observation tombstones are soft-deletes, so FK cascade
   is not a cleanup mechanism for embeddings. This cleanup also applies to

--- a/README.md
+++ b/README.md
@@ -332,7 +332,8 @@ require `--embedding-base-url`, `--embedding-model`, and
 `localhost` or a loopback IP also require the explicit
 `--allow-remote-embeddings` flag. Host aliases are not DNS-resolved for this
 trust decision. Environment variables can set provider details, but remote opt-in
-is intentionally CLI-only. Semantic apply does not exist.
+is intentionally CLI-only. Semantic candidate reports are planned as a separate
+read-only step; semantic apply does not exist.
 
 ## Design principles
 


### PR DESCRIPTION
## Summary
- Update the canonical implementation plan with Step 7.2 for semantic report-only candidates.
- Clarify that the current semantic command remains validation-only until a separate report-mode contract lands.
- Document the no-apply/read-only boundaries for future semantic reports in architecture, operations, API contract, README, and Copilot instructions.

## Validation
- `git diff --check`