### PR TITLE
Add semantic report clusters

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -172,8 +172,10 @@ tool schema.
   report behavior.
 - `--mode report` opens an existing global or project DB, populates/reuses the
   `observation_embeddings` cache, and writes a markdown report of same-entity
-  semantic candidates. It does not run schema migrations; if the DB is too old
-  for semantic report mode, it fails closed. It has no apply path.
+  semantic candidates. The report groups pairwise candidates into observation
+  clusters and includes manual decision checkboxes so review can proceed as a
+  human-authored cleanup spec. It does not run schema migrations; if the DB is
+  too old for semantic report mode, it fails closed. It has no apply path.
 
 - The default embedding provider is `none`.
 - Supported provider identifiers are `none`, `openai-compatible`, `ollama`, and
@@ -208,3 +210,7 @@ tool schema.
   but must not include response bodies, prompts, endpoint keys, credentials, or
   memory content. The markdown report itself intentionally includes bounded
   candidate snippets for human review and is written as a local private file.
+- Optional model-assisted cleanup proposals are outside the executable API
+  contract. Users may review report files with a model/provider they choose, but
+  `workmem` must not call an LLM or apply proposal output as part of semantic
+  report mode.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -120,13 +120,20 @@ superseded, and expired-event observations. It must not mutate
 observations, supersession fields, reconcile audit rows, access counts, or FTS
 state. Report orchestration chunks provider requests, caps observations and
 candidate output per entity, and emits limit signals when caps truncate work so
-resource protection is visible rather than silent. Provider diagnostics are
-sanitized to status/transport shape only; response bodies and memory content do
-not enter provider errors. Reports intentionally include bounded candidate
-snippets so a human can judge false positives; report files are local, ignored,
-and written with private permissions. Since observations are tombstoned rather
-than hard-deleted, `forget` explicitly removes embedding rows instead of relying
-on foreign-key cascade cleanup.
+resource protection is visible rather than silent. The renderer groups pairwise
+candidates into same-entity observation clusters and adds manual decision
+checkboxes; clusters are review scaffolding, not executable decisions. Provider
+diagnostics are sanitized to status/transport shape only; response bodies and
+memory content do not enter provider errors. Reports intentionally include
+bounded candidate snippets so a human can judge false positives; report files are
+local, ignored, and written with private permissions. Since observations are
+tombstoned rather than hard-deleted, `forget` explicitly removes embedding rows
+instead of relying on foreign-key cascade cleanup.
+
+Model-assisted cleanup proposals are intentionally outside the core architecture:
+the public contract provides provider-neutral prompt guidance, while users choose
+their own model and privacy boundary. Proposal output is advisory input for a
+human review session, not a machine-readable apply plan.
 
 Semantic apply remains out of architecture until report false-positive rates are
 proven boring. Exact-duplicate apply is still the only reconcile mutation path.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -397,3 +397,22 @@ still proves that only `observation_embeddings` cache rows may change.
 focus: chunking must preserve cache identity/order, caps must fail closed or
 report truncation explicitly, provider errors must not leak sensitive data, and
 no semantic apply route may appear.
+
+### Step 7.4: Semantic report review scaffolding [✅]
+
+Make low-threshold semantic scouting usable as a manual cleanup spec without
+adding any semantic mutation path. **Gate:** semantic reports group pairwise
+candidates into same-entity observation clusters with manual decision checkboxes,
+while preserving report-only/cache-write-only behavior.
+
+- [x] Group same-entity candidate pairs into connected observation clusters
+- [x] Render cluster summary, top pairs, and manual decision checklist before the
+  pairwise candidate table
+- [x] Keep semantic report output local/private and non-executable
+- [x] Document optional model-assisted proposal review as provider-neutral and
+  human-only
+- [x] Update README, API contract, and architecture docs for cluster scaffolding
+
+**On Step Gate (all items [x]):** focused correctness/architecture review. Review
+focus: clusters must be derived only from report candidates, must not imply
+automatic apply, and must not widen matching beyond same-entity candidates.

--- a/README.md
+++ b/README.md
@@ -347,7 +347,8 @@ writes are the only allowed persistence. Embedding requests are chunked by
 `--max-embeddings-per-request`; per-entity comparison/output work is bounded by
 `--max-observations-per-entity` and `--max-candidates-per-entity`, with limit
 signals written to the report. Reports include bounded candidate snippets for
-human review and are local/private markdown files. Semantic apply does not exist.
+human review, candidate clusters, and manual decision checkboxes; they are
+local/private markdown files. Semantic apply does not exist.
 
 The default provider is `none`. Non-`none` providers require
 `--embedding-base-url`, `--embedding-model`, and `--embedding-dimensions`.
@@ -357,6 +358,51 @@ not literal `localhost` or a loopback IP require the explicit
 `--allow-remote-embeddings` flag. Host aliases are not DNS-resolved for this
 trust decision. Environment variables can set provider details, but remote opt-in
 is intentionally CLI-only.
+
+### Optional model-assisted cleanup proposal
+
+Semantic reports are evidence, not executable plans. You may paste a report into
+an LLM you trust to draft a human cleanup proposal, but `workmem` does not call
+that model or apply its suggestions. Reports contain memory snippets; only send
+them to providers you are comfortable sharing that local/private content with.
+
+Use a provider and model of your choice. A useful prompt shape is:
+
+```text
+You are a conservative memory hygiene reviewer. Analyze this semantic reconcile
+report as a human cleanup spec. Do not execute actions. Do not output tool calls.
+
+Core rules:
+1. First classify relationship_type, then suggest action.
+2. Semantic similarity means relatedness, not duplication.
+3. Preserve timeline facts: opened vs merged, draft vs implemented, phase N vs
+   phase N+1, and different commits/dates are not duplicates by default.
+4. A source may be forgotten only if a proposed new observation fully preserves
+   every distinct fact visible in the snippets.
+5. Large heterogeneous clusters must be split by subtheme, not consolidated.
+
+Allowed relationship_type values:
+- lifecycle_pair
+- same_topic_distinct_facts
+- possible_duplicate
+- broad_topic_blob
+- scope_mismatch
+- insufficient_evidence
+
+Allowed action values:
+- keep_all
+- draft_synthetic_keep_sources
+- draft_synthetic_then_human_may_forget
+- split_into_subthemes
+- move_scope_review
+- inspect_only
+
+Return:
+- threshold_assessment
+- stable_prompt_invariants
+- cluster_decisions as JSON
+- self_critique
+```
 
 ## Design principles
 

--- a/internal/reconcile/report.go
+++ b/internal/reconcile/report.go
@@ -377,7 +377,7 @@ func buildSemanticClusters(candidates []semantic.Candidate) []semanticCluster {
 		if clusters[i].EntityName != clusters[j].EntityName {
 			return clusters[i].EntityName < clusters[j].EntityName
 		}
-		return joinObservationIDs(clusters[i].ObservationIDs) < joinObservationIDs(clusters[j].ObservationIDs)
+		return lessObservationIDs(clusters[i].ObservationIDs, clusters[j].ObservationIDs)
 	})
 	for i := range clusters {
 		clusters[i].Index = i + 1
@@ -458,6 +458,19 @@ func joinObservationIDs(ids []int64) string {
 		parts = append(parts, fmt.Sprintf("%d", id))
 	}
 	return strings.Join(parts, ", ")
+}
+
+func lessObservationIDs(left []int64, right []int64) bool {
+	limit := len(left)
+	if len(right) < limit {
+		limit = len(right)
+	}
+	for i := 0; i < limit; i++ {
+		if left[i] != right[i] {
+			return left[i] < right[i]
+		}
+	}
+	return len(left) < len(right)
 }
 
 func markdownCell(value string) string {

--- a/internal/reconcile/report.go
+++ b/internal/reconcile/report.go
@@ -389,7 +389,7 @@ func semanticClusterEntityKey(candidate semantic.Candidate) string {
 	if candidate.EntityID != 0 {
 		return fmt.Sprintf("entity-id:%d", candidate.EntityID)
 	}
-	return fmt.Sprintf("entity-name:%s\x00%s", candidate.EntityName, candidate.EntityType)
+	return fmt.Sprintf("entity-name:%s\x00%s", strings.TrimSpace(candidate.EntityName), strings.TrimSpace(candidate.EntityType))
 }
 
 func ensureSemanticClusterNode(parents map[int64]int64, obsID int64) {

--- a/internal/reconcile/report.go
+++ b/internal/reconcile/report.go
@@ -6,6 +6,7 @@ import (
 	"html"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -13,6 +14,8 @@ import (
 	"workmem/internal/semantic"
 	"workmem/internal/store"
 )
+
+const semanticClusterTopPairs = 5
 
 func DefaultReportPath(now time.Time) string {
 	if now.IsZero() {
@@ -175,14 +178,69 @@ func RenderSemanticReport(report *semantic.Report) string {
 	fmt.Fprintf(&buf, "- Mutations allowed in this mode: embedding cache writes only.\n")
 	fmt.Fprintf(&buf, "- Mutations forbidden in this mode: observations, supersession fields, reconcile audit rows, access counts, and FTS state.\n\n")
 
+	clusters := buildSemanticClusters(report.Candidates)
+
 	fmt.Fprintf(&buf, "## Summary\n")
 	fmt.Fprintf(&buf, "- Entities scanned: %d\n", len(report.ScannedEntities))
 	fmt.Fprintf(&buf, "- Semantic candidates: %d\n", len(report.Candidates))
+	fmt.Fprintf(&buf, "- Candidate clusters: %d\n", len(clusters))
 	fmt.Fprintf(&buf, "- Embeddings reused from cache: %d\n", report.EmbeddingsReused)
 	fmt.Fprintf(&buf, "- Embeddings cached this run: %d\n", report.EmbeddingsCached)
 	fmt.Fprintf(&buf, "- Embedding requests: %d\n", report.EmbeddingRequests)
 	fmt.Fprintf(&buf, "- Entities with limit signals: %d\n", len(report.EntityLimits))
 	fmt.Fprintf(&buf, "- Memory mutations applied: %d\n\n", report.MemoryMutationsApplied)
+
+	fmt.Fprintf(&buf, "## Candidate clusters\n\n")
+	if len(clusters) == 0 {
+		fmt.Fprintf(&buf, "No candidate clusters found.\n\n")
+	} else {
+		fmt.Fprintf(&buf, "| Entity | Cluster | Obs ids | Pairs | Max sim | Avg sim | Hint | Recommendation |\n")
+		fmt.Fprintf(&buf, "|---|---:|---|---:|---:|---:|---|---|\n")
+		for _, cluster := range clusters {
+			fmt.Fprintf(&buf, "| %s | %d | %s | %d | %.4f | %.4f | %s | inspect |\n",
+				markdownCell(cluster.EntityName),
+				cluster.Index,
+				markdownCell(joinObservationIDs(cluster.ObservationIDs)),
+				len(cluster.Pairs),
+				cluster.MaxSimilarity,
+				cluster.AverageSimilarity,
+				markdownCell(cluster.Hint),
+			)
+		}
+		fmt.Fprintf(&buf, "\n")
+
+		for _, cluster := range clusters {
+			fmt.Fprintf(&buf, "### Cluster %d - %s\n\n", cluster.Index, markdownCell(cluster.EntityName))
+			fmt.Fprintf(&buf, "- Observation ids: `%s`\n", joinObservationIDs(cluster.ObservationIDs))
+			fmt.Fprintf(&buf, "- Pairs above threshold: %d\n", len(cluster.Pairs))
+			fmt.Fprintf(&buf, "- Similarity range: %.4f max, %.4f average\n", cluster.MaxSimilarity, cluster.AverageSimilarity)
+			fmt.Fprintf(&buf, "- Recommendation: inspect before any manual memory action\n")
+			fmt.Fprintf(&buf, "- Top pairs:\n")
+			limit := semanticClusterTopPairs
+			if len(cluster.Pairs) < limit {
+				limit = len(cluster.Pairs)
+			}
+			for i := 0; i < limit; i++ {
+				pair := cluster.Pairs[i]
+				fmt.Fprintf(&buf, "  - `%d` <-> `%d` (%.4f): %s <=> %s\n",
+					pair.TargetObsID,
+					pair.SourceObsID,
+					pair.Similarity,
+					markdownCell(truncateString(pair.TargetContent, 80)),
+					markdownCell(truncateString(pair.SourceContent, 80)),
+				)
+			}
+			if len(cluster.Pairs) > limit {
+				fmt.Fprintf(&buf, "  - ... %d more pair(s) in the pairwise table below\n", len(cluster.Pairs)-limit)
+			}
+			fmt.Fprintf(&buf, "- Manual decision:\n")
+			fmt.Fprintf(&buf, "  - [ ] keep all\n")
+			fmt.Fprintf(&buf, "  - [ ] consolidate into a new observation\n")
+			fmt.Fprintf(&buf, "  - [ ] forget stale observations\n")
+			fmt.Fprintf(&buf, "  - [ ] move scope\n")
+			fmt.Fprintf(&buf, "- Notes:\n\n")
+		}
+	}
 
 	fmt.Fprintf(&buf, "## Semantic candidates\n\n")
 	if len(report.Candidates) == 0 {
@@ -237,6 +295,169 @@ func RenderSemanticReport(report *semantic.Report) string {
 		}
 	}
 	return buf.String()
+}
+
+type semanticCluster struct {
+	Index             int
+	EntityName        string
+	ObservationIDs    []int64
+	Pairs             []semantic.Candidate
+	MaxSimilarity     float64
+	AverageSimilarity float64
+	Hint              string
+}
+
+func buildSemanticClusters(candidates []semantic.Candidate) []semanticCluster {
+	if len(candidates) == 0 {
+		return nil
+	}
+	type entityClusterInput struct {
+		entityName string
+		parents    map[int64]int64
+		pairs      []semantic.Candidate
+	}
+	byEntity := make(map[string]*entityClusterInput)
+	for _, candidate := range candidates {
+		key := semanticClusterEntityKey(candidate)
+		input := byEntity[key]
+		if input == nil {
+			input = &entityClusterInput{
+				entityName: strings.TrimSpace(candidate.EntityName),
+				parents:    make(map[int64]int64),
+			}
+			byEntity[key] = input
+		}
+		ensureSemanticClusterNode(input.parents, candidate.TargetObsID)
+		ensureSemanticClusterNode(input.parents, candidate.SourceObsID)
+		unionSemanticClusterNodes(input.parents, candidate.TargetObsID, candidate.SourceObsID)
+		input.pairs = append(input.pairs, candidate)
+	}
+
+	var clusters []semanticCluster
+	for _, input := range byEntity {
+		componentIDs := make(map[int64][]int64)
+		for obsID := range input.parents {
+			root := findSemanticClusterRoot(input.parents, obsID)
+			componentIDs[root] = append(componentIDs[root], obsID)
+		}
+		componentPairs := make(map[int64][]semantic.Candidate)
+		for _, pair := range input.pairs {
+			root := findSemanticClusterRoot(input.parents, pair.TargetObsID)
+			componentPairs[root] = append(componentPairs[root], pair)
+		}
+		for root, obsIDs := range componentIDs {
+			pairs := componentPairs[root]
+			if len(pairs) == 0 {
+				continue
+			}
+			sort.Slice(obsIDs, func(i, j int) bool { return obsIDs[i] < obsIDs[j] })
+			sortSemanticClusterPairs(pairs)
+			maxSimilarity := pairs[0].Similarity
+			var totalSimilarity float64
+			for _, pair := range pairs {
+				totalSimilarity += pair.Similarity
+			}
+			clusters = append(clusters, semanticCluster{
+				EntityName:        input.entityName,
+				ObservationIDs:    obsIDs,
+				Pairs:             pairs,
+				MaxSimilarity:     maxSimilarity,
+				AverageSimilarity: totalSimilarity / float64(len(pairs)),
+				Hint:              semanticClusterHint(pairs[0]),
+			})
+		}
+	}
+	sort.Slice(clusters, func(i, j int) bool {
+		if clusters[i].MaxSimilarity != clusters[j].MaxSimilarity {
+			return clusters[i].MaxSimilarity > clusters[j].MaxSimilarity
+		}
+		if clusters[i].AverageSimilarity != clusters[j].AverageSimilarity {
+			return clusters[i].AverageSimilarity > clusters[j].AverageSimilarity
+		}
+		if clusters[i].EntityName != clusters[j].EntityName {
+			return clusters[i].EntityName < clusters[j].EntityName
+		}
+		return joinObservationIDs(clusters[i].ObservationIDs) < joinObservationIDs(clusters[j].ObservationIDs)
+	})
+	for i := range clusters {
+		clusters[i].Index = i + 1
+	}
+	return clusters
+}
+
+func semanticClusterEntityKey(candidate semantic.Candidate) string {
+	if candidate.EntityID != 0 {
+		return fmt.Sprintf("entity-id:%d", candidate.EntityID)
+	}
+	return fmt.Sprintf("entity-name:%s\x00%s", candidate.EntityName, candidate.EntityType)
+}
+
+func ensureSemanticClusterNode(parents map[int64]int64, obsID int64) {
+	if _, ok := parents[obsID]; !ok {
+		parents[obsID] = obsID
+	}
+}
+
+func findSemanticClusterRoot(parents map[int64]int64, obsID int64) int64 {
+	parent, ok := parents[obsID]
+	if !ok {
+		parents[obsID] = obsID
+		return obsID
+	}
+	if parent == obsID {
+		return obsID
+	}
+	root := findSemanticClusterRoot(parents, parent)
+	parents[obsID] = root
+	return root
+}
+
+func unionSemanticClusterNodes(parents map[int64]int64, left int64, right int64) {
+	leftRoot := findSemanticClusterRoot(parents, left)
+	rightRoot := findSemanticClusterRoot(parents, right)
+	if leftRoot == rightRoot {
+		return
+	}
+	if leftRoot < rightRoot {
+		parents[rightRoot] = leftRoot
+		return
+	}
+	parents[leftRoot] = rightRoot
+}
+
+func sortSemanticClusterPairs(pairs []semantic.Candidate) {
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].Similarity != pairs[j].Similarity {
+			return pairs[i].Similarity > pairs[j].Similarity
+		}
+		if pairs[i].TargetObsID != pairs[j].TargetObsID {
+			return pairs[i].TargetObsID < pairs[j].TargetObsID
+		}
+		return pairs[i].SourceObsID < pairs[j].SourceObsID
+	})
+}
+
+func semanticClusterHint(candidate semantic.Candidate) string {
+	target := strings.TrimSpace(candidate.TargetContent)
+	source := strings.TrimSpace(candidate.SourceContent)
+	if target == "" {
+		return truncateString(source, 96)
+	}
+	if source == "" {
+		return truncateString(target, 96)
+	}
+	return truncateString(target, 48) + " / " + truncateString(source, 48)
+}
+
+func joinObservationIDs(ids []int64) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, fmt.Sprintf("%d", id))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func markdownCell(value string) string {

--- a/internal/reconcile/report_test.go
+++ b/internal/reconcile/report_test.go
@@ -208,6 +208,32 @@ func TestBuildSemanticClustersUsesEntityIDAcrossEntityTypeSnapshots(t *testing.T
 	}
 }
 
+func TestBuildSemanticClustersNormalizesFallbackEntityKey(t *testing.T) {
+	clusters := buildSemanticClusters([]semantic.Candidate{{
+		EntityName:  " Entity ",
+		EntityType:  " test ",
+		Similarity:  0.8,
+		TargetObsID: 2,
+		SourceObsID: 1,
+	}, {
+		EntityName:  "Entity",
+		EntityType:  "test",
+		Similarity:  0.7,
+		TargetObsID: 3,
+		SourceObsID: 2,
+	}})
+	if len(clusters) != 1 {
+		t.Fatalf("clusters = %d, want 1: %#v", len(clusters), clusters)
+	}
+	cluster := clusters[0]
+	if cluster.EntityName != "Entity" {
+		t.Fatalf("cluster entity name = %q, want Entity", cluster.EntityName)
+	}
+	if got := joinObservationIDs(cluster.ObservationIDs); got != "1, 2, 3" {
+		t.Fatalf("cluster obs ids = %q, want 1, 2, 3", got)
+	}
+}
+
 func TestLessObservationIDsComparesWithoutStringKeys(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/reconcile/report_test.go
+++ b/internal/reconcile/report_test.go
@@ -132,6 +132,13 @@ func TestRenderSemanticReportIncludesSafetyAndEscapesCells(t *testing.T) {
 			SourceObsID:   10,
 			TargetContent: "target | [link](x)",
 			SourceContent: "source | *bold*",
+		}, {
+			EntityName:    "Entity|One<script>",
+			Similarity:    0.9,
+			TargetObsID:   20,
+			SourceObsID:   30,
+			TargetContent: "target | [link](x)",
+			SourceContent: "second source",
 		}},
 		EntityLimits: []semantic.EntityLimit{{
 			EntityName:             "Entity|One<script>",
@@ -149,6 +156,14 @@ func TestRenderSemanticReportIncludesSafetyAndEscapesCells(t *testing.T) {
 		"Max embeddings per request: 64",
 		"Mutations allowed in this mode: embedding cache writes only.",
 		"- Memory mutations applied: 0",
+		"- Candidate clusters: 1",
+		"## Candidate clusters",
+		"| Entity | Cluster | Obs ids | Pairs | Max sim | Avg sim | Hint | Recommendation |",
+		"| Entity\\|One&lt;script&gt; | 1 | 10, 20, 30 | 2 | 0.9876 | 0.9438 |",
+		"### Cluster 1 - Entity\\|One&lt;script&gt;",
+		"- Observation ids: `10, 20, 30`",
+		"- Manual decision:",
+		"  - [ ] consolidate into a new observation",
 		"| Entity | Similarity | Target obs | Source obs | Target content | Source content |",
 		"Entity\\|One&lt;script&gt;",
 		"target \\| \\[link\\]\\(x\\)",
@@ -162,6 +177,34 @@ func TestRenderSemanticReportIncludesSafetyAndEscapesCells(t *testing.T) {
 	}
 	if strings.Contains(rendered, report.EndpointKey) {
 		t.Fatalf("semantic report leaked endpoint key:\n%s", rendered)
+	}
+}
+
+func TestBuildSemanticClustersUsesEntityIDAcrossEntityTypeSnapshots(t *testing.T) {
+	clusters := buildSemanticClusters([]semantic.Candidate{{
+		EntityID:    42,
+		EntityName:  "Entity",
+		EntityType:  "old-type",
+		Similarity:  0.8,
+		TargetObsID: 2,
+		SourceObsID: 1,
+	}, {
+		EntityID:    42,
+		EntityName:  "Entity",
+		EntityType:  "new-type",
+		Similarity:  0.7,
+		TargetObsID: 3,
+		SourceObsID: 2,
+	}})
+	if len(clusters) != 1 {
+		t.Fatalf("clusters = %d, want 1: %#v", len(clusters), clusters)
+	}
+	cluster := clusters[0]
+	if got := joinObservationIDs(cluster.ObservationIDs); got != "1, 2, 3" {
+		t.Fatalf("cluster obs ids = %q, want 1, 2, 3", got)
+	}
+	if len(cluster.Pairs) != 2 {
+		t.Fatalf("cluster pairs = %d, want 2", len(cluster.Pairs))
 	}
 }
 

--- a/internal/reconcile/report_test.go
+++ b/internal/reconcile/report_test.go
@@ -208,6 +208,27 @@ func TestBuildSemanticClustersUsesEntityIDAcrossEntityTypeSnapshots(t *testing.T
 	}
 }
 
+func TestLessObservationIDsComparesWithoutStringKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  []int64
+		right []int64
+		want  bool
+	}{
+		{name: "lexicographic", left: []int64{1, 20}, right: []int64{1, 100}, want: true},
+		{name: "prefix shorter first", left: []int64{1}, right: []int64{1, 2}, want: true},
+		{name: "equal", left: []int64{1, 2}, right: []int64{1, 2}, want: false},
+		{name: "greater", left: []int64{2}, right: []int64{1, 100}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lessObservationIDs(tt.left, tt.right); got != tt.want {
+				t.Fatalf("lessObservationIDs(%v, %v) = %v, want %v", tt.left, tt.right, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWriteSemanticReportCreatesPrivateMarkdownFile(t *testing.T) {
 	report := &semantic.Report{
 		GeneratedAt: time.Date(2026, 5, 4, 8, 0, 0, 0, time.UTC),


### PR DESCRIPTION
## Summary
- Group semantic report candidate pairs into same-entity observation clusters with max/average similarity, top pairs, and manual decision checkboxes.
- Document provider-neutral, privacy-aware optional LLM review guidance without adding any LLM call or semantic apply path.
- Keep semantic report mode report-only/cache-write-only and preserve same-entity candidate boundaries.

## Validation
- `go test ./internal/reconcile ./internal/semantic ./cmd/workmem`
- `go test ./...`
- `git diff --check`
- Local correctness/architecture review rerun: no Blocker/Risk